### PR TITLE
Add pre-push hook to run golangci-lint locally

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ensure GOBIN is on PATH (common when installed via go install)
+export PATH="${GOPATH:-$HOME/go}/bin:$PATH"
+
+echo "pre-push: running golangci-lint..."
+
+if ! command -v golangci-lint &>/dev/null; then
+  echo "error: golangci-lint not found in PATH"
+  echo "install: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.0"
+  exit 1
+fi
+
+golangci-lint run
+echo "pre-push: lint passed"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test lint golden-update clean
+.PHONY: build test lint golden-update clean install-hooks
 
 build:
 	go build ./cmd/imagine-tui
@@ -11,6 +11,9 @@ lint:
 
 golden-update:
 	GOLDEN_UPDATE=1 go test ./internal/widget/...
+
+install-hooks:
+	git config core.hooksPath .githooks
 
 clean:
 	rm -f imagine-tui


### PR DESCRIPTION
Adds a version-controlled pre-push hook that runs `golangci-lint run` (v2.11.0) before allowing pushes, catching lint failures locally instead of in CI. The hook lives in `.githooks/` and is activated via `make install-hooks`, which sets `core.hooksPath` — this applies automatically to all worktrees. Developers without golangci-lint installed get a helpful error message with install instructions.