### PR TITLE
M6: Address MCP feedback — log append, scripting discovery, patch append

### DIFF
--- a/cmd/imagine-tui/main.go
+++ b/cmd/imagine-tui/main.go
@@ -3,8 +3,11 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"io"
+	"log/slog"
+	"net"
 	"os"
 	"os/signal"
 	"syscall"
@@ -17,41 +20,87 @@ import (
 )
 
 func main() {
-	if len(os.Args) > 1 && os.Args[1] == "serve" {
-		if err := serve(); err != nil {
-			fmt.Fprintf(os.Stderr, "imagine-tui: %v\n", err)
-			os.Exit(1)
-		}
-		return
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "Usage: imagine-tui <serve|connect> [flags]")
+		os.Exit(1)
 	}
-	fmt.Println("Usage: imagine-tui serve")
+
+	var err error
+	switch os.Args[1] {
+	case "serve":
+		err = serve(os.Args[2:])
+	case "connect":
+		err = connectCmd(os.Args[2:])
+	default:
+		fmt.Fprintf(os.Stderr, "Unknown command: %s\nUsage: imagine-tui <serve|connect> [flags]\n", os.Args[1])
+		os.Exit(1)
+	}
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "imagine-tui %s: %v\n", os.Args[1], err)
+		os.Exit(1)
+	}
 }
 
-func serve() error {
+// initLogger sets up slog to write JSON to the given file path.
+// If logPath is empty, logging is discarded.
+func initLogger(logPath string) (*slog.Logger, func(), error) {
+	if logPath == "" {
+		return slog.New(slog.NewTextHandler(io.Discard, nil)), func() {}, nil
+	}
+	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open log file: %w", err)
+	}
+	logger := slog.New(slog.NewJSONHandler(f, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	return logger, func() { _ = f.Close() }, nil
+}
+
+func serve(args []string) error {
+	fs := flag.NewFlagSet("serve", flag.ExitOnError)
+	socketPath := fs.String("socket", "", "Unix socket path for MCP transport (if omitted, uses stdio)")
+	logPath := fs.String("log", "", "Log file path (if omitted, no logging)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	logger, closeLog, err := initLogger(*logPath)
+	if err != nil {
+		return err
+	}
+	defer closeLog()
+
+	logger.Info("starting imagine-tui", "socket", *socketPath)
+
 	// Create the MCP server.
 	srv, err := imcp.NewServer()
 	if err != nil {
 		return fmt.Errorf("create server: %w", err)
 	}
+	srv.SetLogger(logger)
 
-	// Create the BubbleTea model.
+	if *socketPath != "" {
+		return serveSocket(srv, *socketPath, logger)
+	}
+	return serveStdio(srv, logger)
+}
+
+// serveStdio runs MCP over stdin/stdout with BubbleTea on stderr.
+func serveStdio(srv *imcp.Server, logger *slog.Logger) error {
 	registry := widget.DefaultRegistry()
 	model := render.NewModel(srv, registry)
+	model.SetLogger(logger)
 
-	// Start the BubbleTea program.
 	// Use stderr for TUI output since stdout is used by MCP stdio transport.
 	program := tea.NewProgram(model,
 		tea.WithOutput(os.Stderr),
 		tea.WithAltScreen(),
 	)
 
-	// Create the bridge so MCP can notify BubbleTea of DOM changes.
+	// Wire bridge: MCP mutations → BubbleTea re-renders.
 	bridge := render.NewBridge(srv, program)
-	bridge.OnMutation = func() {
-		// Widget tree sync happens in the BubbleTea Update loop.
-	}
+	srv.SetOnMutation(bridge.NotifyDOMChanged)
 
-	// Handle graceful shutdown on signals.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -60,19 +109,20 @@ func serve() error {
 	go func() {
 		select {
 		case <-sigCh:
+			logger.Info("signal received, shutting down")
 			srv.Shutdown()
 			program.Send(render.ShutdownMsg{})
 		case <-ctx.Done():
 		}
 	}()
 
-	// Start the MCP server on stdio in a goroutine.
+	// Start MCP on stdio.
 	mcpErrCh := make(chan error, 1)
 	go func() {
+		logger.Info("MCP server starting on stdio")
 		err := srv.MCPServer().Run(ctx, &mcp.StdioTransport{})
 		mcpErrCh <- err
-
-		// If MCP disconnects (broken pipe), notify BubbleTea.
+		logger.Info("MCP stdio session ended", "error", err)
 		if err != nil && err != io.EOF {
 			bridge.NotifyDisconnected(err)
 		} else {
@@ -80,11 +130,10 @@ func serve() error {
 		}
 	}()
 
-	// Run the BubbleTea program (blocks until quit).
-	_, err = program.Run()
-	cancel() // Stop MCP server when TUI exits.
+	// Run BubbleTea (blocks until quit).
+	_, err := program.Run()
+	cancel()
 
-	// Wait briefly for MCP server to finish.
 	select {
 	case mcpErr := <-mcpErrCh:
 		if mcpErr != nil && mcpErr != io.EOF && mcpErr != context.Canceled {
@@ -95,4 +144,123 @@ func serve() error {
 
 	srv.Shutdown()
 	return err
+}
+
+// serveSocket runs MCP over a Unix domain socket with BubbleTea on stdout.
+func serveSocket(srv *imcp.Server, socketPath string, logger *slog.Logger) error {
+	// Clean up stale socket file.
+	if err := os.Remove(socketPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove stale socket: %w", err)
+	}
+
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		return fmt.Errorf("listen on %s: %w", socketPath, err)
+	}
+	defer func() { _ = listener.Close() }()
+	defer func() { _ = os.Remove(socketPath) }()
+
+	registry := widget.DefaultRegistry()
+	model := render.NewModel(srv, registry)
+	model.SetLogger(logger)
+
+	// BubbleTea uses stdout directly — no MCP contention on stdio.
+	program := tea.NewProgram(model,
+		tea.WithAltScreen(),
+	)
+
+	// Wire bridge: MCP mutations → BubbleTea re-renders.
+	bridge := render.NewBridge(srv, program)
+	srv.SetOnMutation(bridge.NotifyDOMChanged)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		select {
+		case <-sigCh:
+			logger.Info("signal received, shutting down")
+			srv.Shutdown()
+			program.Send(render.ShutdownMsg{})
+			_ = listener.Close()
+		case <-ctx.Done():
+		}
+	}()
+
+	// Accept MCP connections on the Unix socket.
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				logger.Debug("accept ended", "error", err)
+				return // listener closed
+			}
+			logger.Info("client connected", "remote", conn.RemoteAddr())
+			go handleConnection(ctx, srv, bridge, conn, logger)
+		}
+	}()
+
+	logger.Info("listening", "socket", socketPath)
+	fmt.Fprintf(os.Stderr, "Listening on %s\n", socketPath)
+
+	// Run BubbleTea (blocks until quit).
+	_, err = program.Run()
+	cancel()
+	srv.Shutdown()
+	return err
+}
+
+func handleConnection(ctx context.Context, srv *imcp.Server, bridge *render.Bridge, conn net.Conn, logger *slog.Logger) {
+	defer func() { _ = conn.Close() }()
+
+	transport := &mcp.IOTransport{
+		Reader: conn,
+		Writer: conn,
+	}
+
+	session, err := srv.MCPServer().Connect(ctx, transport, nil)
+	if err != nil {
+		logger.Error("MCP connect failed", "error", err)
+		return
+	}
+
+	bridge.NotifyConnected()
+	logger.Info("MCP session established")
+
+	err = session.Wait()
+	logger.Info("MCP session ended", "error", err)
+	if err != nil && err != io.EOF && err != context.Canceled {
+		bridge.NotifyDisconnected(err)
+	}
+}
+
+// connectCmd dials a Unix socket and bridges stdin/stdout to it.
+// Used by Claude Code's .mcp.json: {"command": "imagine-tui", "args": ["connect", "<socket>"]}
+func connectCmd(args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("usage: imagine-tui connect <socket-path>")
+	}
+	socketPath := args[0]
+
+	conn, err := net.Dial("unix", socketPath)
+	if err != nil {
+		return fmt.Errorf("dial %s: %w", socketPath, err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	// Bidirectional copy: stdin → socket, socket → stdout.
+	errCh := make(chan error, 2)
+	go func() {
+		_, err := io.Copy(conn, os.Stdin)
+		errCh <- err
+	}()
+	go func() {
+		_, err := io.Copy(os.Stdout, conn)
+		errCh <- err
+	}()
+
+	// Wait for either direction to finish.
+	return <-errCh
 }

--- a/cmd/imagine-tui/serve_test.go
+++ b/cmd/imagine-tui/serve_test.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	imcp "github.com/joncooper/imagine-tui/internal/mcp"
+	"github.com/joncooper/imagine-tui/internal/render"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// mockProgram captures messages sent from the bridge.
+type mockProgram struct {
+	msgs []tea.Msg
+}
+
+func (m *mockProgram) Send(msg tea.Msg) {
+	m.msgs = append(m.msgs, msg)
+}
+
+func TestUnixSocketIntegration(t *testing.T) {
+	// Create server.
+	srv, err := imcp.NewServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Shutdown()
+
+	// Wire mutation callback through the bridge.
+	mp := &mockProgram{}
+	bridge := render.NewBridge(srv, mp)
+	var mutationCount atomic.Int32
+	srv.SetOnMutation(func() {
+		mutationCount.Add(1)
+		bridge.NotifyDOMChanged()
+	})
+
+	// Listen on a temp Unix socket.
+	socketPath := filepath.Join(t.TempDir(), "test.sock")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = listener.Close() }()
+	defer func() { _ = os.Remove(socketPath) }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Accept one connection.
+	connCh := make(chan net.Conn, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		connCh <- conn
+	}()
+
+	// Dial the socket from the client side.
+	clientConn, err := net.Dial("unix", socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = clientConn.Close() }()
+
+	// Server side: wrap connection in IOTransport and connect.
+	serverConn := <-connCh
+	defer func() { _ = serverConn.Close() }()
+
+	serverTransport := &mcp.IOTransport{
+		Reader: serverConn,
+		Writer: serverConn,
+	}
+	_, err = srv.MCPServer().Connect(ctx, serverTransport, nil)
+	if err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+
+	// Client side: wrap connection in IOTransport and connect.
+	clientTransport := &mcp.IOTransport{
+		Reader: clientConn,
+		Writer: clientConn,
+	}
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0.0.1"}, nil)
+	cs, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	defer func() { _ = cs.Close() }()
+
+	// ListTools — verify all 6 tools are present.
+	tools, err := cs.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tools.Tools) != 12 {
+		names := make([]string, len(tools.Tools))
+		for i, tool := range tools.Tools {
+			names[i] = tool.Name
+		}
+		t.Fatalf("expected 12 tools, got %d: %v", len(tools.Tools), names)
+	}
+
+	// Call replace to set up a tree.
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "replace",
+		Arguments: map[string]any{
+			"tree": map[string]any{
+				"id":   "root",
+				"type": "container",
+				"children": []any{
+					map[string]any{
+						"id":    "header",
+						"type":  "text",
+						"props": map[string]any{"content": "Hello from socket"},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("replace returned error: %v", result.Content)
+	}
+
+	// Verify mutation callback fired.
+	if mutationCount.Load() != 1 {
+		t.Fatalf("expected 1 mutation, got %d", mutationCount.Load())
+	}
+
+	// Verify bridge sent DOMChangedMsg.
+	if len(mp.msgs) == 0 {
+		t.Fatal("expected DOMChangedMsg, got none")
+	}
+	if _, ok := mp.msgs[0].(render.DOMChangedMsg); !ok {
+		t.Fatalf("expected DOMChangedMsg, got %T", mp.msgs[0])
+	}
+
+	// Call query to verify state.
+	qResult, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "query",
+		Arguments: map[string]any{"ids": []any{"header"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if qResult.IsError {
+		t.Fatalf("query returned error: %v", qResult.Content)
+	}
+}

--- a/demo/log-viewer/.bak.CLAUDE.md
+++ b/demo/log-viewer/.bak.CLAUDE.md
@@ -1,0 +1,125 @@
+# Log Viewer Demo — Claude Code System Prompt
+
+You have access to **imagine-tui**, an MCP server that renders interactive terminal UIs. Use its tools to build a log viewer for the user.
+
+## Getting started
+
+**First, call `imagine_tui.describe_widgets`** to discover available widget types, their props, and events. This tells you what you can build with.
+
+## Available MCP tools
+
+### Discovery
+
+- `imagine_tui.describe_widgets` — List all widget types with props, events, and capabilities. Call with `{"type": "list"}` for details on a specific type.
+
+### Data tools (preferred — use these for data-heavy UIs)
+
+- `imagine_tui.layout` — Define the UI structure. Idempotent — call once to set up the layout.
+- `imagine_tui.set_items` — Populate a `list` or `table` widget with data items. Replaces all existing items.
+- `imagine_tui.append_items` — Append data items without replacing existing items.
+- `imagine_tui.remove_items` — Remove items by `id`.
+
+### Low-level tools (escape-hatch for raw DOM manipulation)
+
+- `imagine_tui.replace` — Replace the entire DOM tree or a subtree
+- `imagine_tui.patch` — Apply incremental updates (update, insert, remove, move)
+
+### Interaction tools
+
+- `imagine_tui.await_event` — Block until the user interacts with the UI (long-poll)
+- `imagine_tui.query` — Read current state of specific nodes
+- `imagine_tui.snapshot` / `imagine_tui.restore` — Save/restore DOM checkpoints
+
+## How to build the log viewer
+
+When the user asks you to build a log viewer:
+
+1. **Call `describe_widgets`** to learn what's available
+2. **Read the log file** from `sample-data/app.log`
+3. **Parse the log entries** — each line has format: `TIMESTAMP SEVERITY [component] message`
+4. **Call `layout`** to define the UI structure:
+
+```json
+{
+  "tree": {
+    "id": "root",
+    "type": "container",
+    "props": { "direction": "vertical" },
+    "children": [
+      {
+        "id": "header",
+        "type": "text",
+        "props": { "content": "Log Viewer", "style": "bold" }
+      },
+      {
+        "id": "main",
+        "type": "container",
+        "props": { "direction": "horizontal" },
+        "children": [
+          {
+            "id": "sidebar",
+            "type": "container",
+            "props": { "direction": "vertical", "width": "25%", "padding": 1 },
+            "children": [
+              { "id": "filter-label", "type": "text", "props": { "content": "Severity Filter", "style": "bold" } },
+              { "id": "sev-error", "type": "button", "props": { "label": "ERROR" } },
+              { "id": "sev-warn", "type": "button", "props": { "label": "WARN" } },
+              { "id": "sev-info", "type": "button", "props": { "label": "INFO" } },
+              { "id": "sev-debug", "type": "button", "props": { "label": "DEBUG" } },
+              { "id": "search", "type": "input", "props": { "placeholder": "Search logs..." } }
+            ]
+          },
+          {
+            "id": "log-entries",
+            "type": "list",
+            "props": { "filterable": false }
+          }
+        ]
+      },
+      {
+        "id": "status-bar",
+        "type": "text",
+        "props": { "content": "0 entries", "style": "dim" }
+      }
+    ]
+  }
+}
+```
+
+5. **Populate the log entries** with `set_items` — send items with `id`, `label`, and optional `badge`/`style`:
+
+```json
+{
+  "target": "log-entries",
+  "items": [
+    { "id": "1", "label": "[server] Starting HTTP server on :8080", "badge": "INFO", "style": "dim" },
+    { "id": "2", "label": "[cache] Connection failed", "badge": "ERROR", "style": "bold" }
+  ]
+}
+```
+
+Format each log entry as: `label` = the message, `badge` = severity level (shown right-aligned), `style` = visual style (ERROR/WARN → "bold", INFO/DEBUG → "dim").
+
+6. **Update the status bar** with a `patch`:
+
+```json
+{
+  "ops": [
+    { "op": "update", "id": "status-bar", "props": { "content": "500 entries loaded" } }
+  ]
+}
+```
+
+7. **Enter the event loop**: call `await_event` and respond to user interactions:
+   - **List select** (Enter on a log entry): show the full log entry details (e.g. update a detail text node)
+   - **Button click** (severity filter): call `set_items` with filtered entries
+   - **Input change** (search): call `set_items` with matching entries
+   - **Always update** the status bar with the current count via `patch`
+
+## Important notes
+
+- Parse log entries from the file, don't invent them
+- Use `layout` + `set_items` instead of generating large JSON patches — it's 10-20x fewer tokens
+- The `list` widget supports up/down arrow navigation and Enter to select — users expect this
+- Update the status bar count whenever you filter entries
+- Use the `await_event` → `set_items` + `patch` loop to keep the UI responsive

--- a/demo/log-viewer/.mcp.json
+++ b/demo/log-viewer/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "imagine-tui": {
+      "command": "/Users/jdc/conductor/workspaces/imagine-tui/boise/imagine-tui",
+      "args": ["connect", "/tmp/imagine-tui.sock"]
+    }
+  }
+}

--- a/demo/log-viewer/README.md
+++ b/demo/log-viewer/README.md
@@ -1,0 +1,60 @@
+# Log Viewer Demo
+
+First end-to-end demo of imagine-tui. A user prompts Claude Code to build a log viewer, and Claude Code constructs the TUI using imagine-tui's MCP tools.
+
+## Prerequisites
+
+- imagine-tui binary built: `go build -o imagine-tui ./cmd/imagine-tui` (from repo root)
+- Binary on `$PATH` (or use an absolute path in `.mcp.json`)
+- Claude Code CLI installed
+
+## How to run
+
+This demo uses two terminals. The imagine-tui server renders the TUI in one terminal and accepts MCP tool calls over a Unix socket from Claude Code running in the other.
+
+### Terminal A — Start the TUI server
+
+```bash
+cd <repo-root>
+./imagine-tui serve --socket /tmp/imagine-tui.sock
+```
+
+The server will start and show a blank TUI, listening for MCP connections on the Unix socket.
+
+### Terminal B — Start Claude Code
+
+```bash
+cd demo/log-viewer
+claude
+```
+
+Claude Code will read `CLAUDE.md`, discover the imagine-tui MCP server via `.mcp.json`, and wait for your prompt. The `.mcp.json` tells Claude Code to spawn `imagine-tui connect /tmp/imagine-tui.sock` as a stdio subprocess that bridges to the Unix socket.
+
+### Prompt Claude Code
+
+```
+Build me a log viewer for the sample data in sample-data/app.log
+```
+
+Claude Code will:
+1. Read the sample log file
+2. Call `imagine_tui.replace` to construct the UI (log widget, severity filters, search input, status bar)
+3. Call `imagine_tui.await_event` to wait for your interaction
+4. Respond to button clicks and search input with filtered views
+
+Watch Terminal A — the TUI will appear and update as Claude builds it.
+
+## Architecture
+
+```
+Terminal A                          Terminal B
+┌──────────────────────┐           ┌──────────────────────┐
+│ imagine-tui serve    │           │ claude               │
+│   --socket *.sock    │◄──Unix──► │   (this session)     │
+│                      │  socket   │                      │
+│ BubbleTea renders    │           │ Reads CLAUDE.md,     │
+│ the TUI on stdout    │           │ calls MCP tools      │
+└──────────────────────┘           └──────────────────────┘
+```
+
+Terminal isolation is achieved via **Unix domain socket transport**: the TUI server owns Terminal A for rendering (stdout), while MCP communication happens over a Unix socket. Claude Code spawns `imagine-tui connect <path>` which bridges stdio to the socket, so from Claude Code's perspective it looks like a normal stdio MCP server.

--- a/demo/log-viewer/sample-data/app.log
+++ b/demo/log-viewer/sample-data/app.log
@@ -1,0 +1,509 @@
+2026-03-13T10:00:00.012Z INFO  [server] Imagine TUI Service v2.4.1 starting up
+2026-03-13T10:00:00.013Z INFO  [server] Loading configuration from /etc/imagine-tui/config.yaml
+2026-03-13T10:00:00.018Z DEBUG [server] Config loaded: environment=production, log_level=debug
+2026-03-13T10:00:00.019Z DEBUG [server] Initializing connection pools
+2026-03-13T10:00:00.045Z INFO  [db] Connecting to PostgreSQL at db-primary.internal:5432
+2026-03-13T10:00:00.187Z INFO  [db] Connection established, pool_size=20, idle=5
+2026-03-13T10:00:00.188Z DEBUG [db] Running migration check against schema_version table
+2026-03-13T10:00:00.201Z INFO  [db] Schema is up to date at version 47
+2026-03-13T10:00:00.210Z INFO  [cache] Connecting to Redis cluster at cache.internal:6379
+2026-03-13T10:00:00.298Z INFO  [cache] Redis connection established, cluster_nodes=3
+2026-03-13T10:00:00.299Z DEBUG [cache] Cache TTL defaults: session=3600s, query=300s, static=86400s
+2026-03-13T10:00:00.305Z INFO  [auth] Loading JWT signing keys from vault
+2026-03-13T10:00:00.412Z INFO  [auth] JWT keys loaded, algorithm=RS256, kid=key-2026-03
+2026-03-13T10:00:00.415Z INFO  [worker] Starting background worker pool, workers=4
+2026-03-13T10:00:00.416Z DEBUG [worker] Worker-0 ready
+2026-03-13T10:00:00.416Z DEBUG [worker] Worker-1 ready
+2026-03-13T10:00:00.417Z DEBUG [worker] Worker-2 ready
+2026-03-13T10:00:00.417Z DEBUG [worker] Worker-3 ready
+2026-03-13T10:00:00.420Z INFO  [server] Registering API routes
+2026-03-13T10:00:00.421Z DEBUG [server] Route registered: GET /api/v1/health
+2026-03-13T10:00:00.421Z DEBUG [server] Route registered: GET /api/v1/users/:id
+2026-03-13T10:00:00.421Z DEBUG [server] Route registered: POST /api/v1/users
+2026-03-13T10:00:00.422Z DEBUG [server] Route registered: GET /api/v1/projects/:id
+2026-03-13T10:00:00.422Z DEBUG [server] Route registered: POST /api/v1/projects
+2026-03-13T10:00:00.422Z DEBUG [server] Route registered: GET /api/v1/widgets
+2026-03-13T10:00:00.423Z DEBUG [server] Route registered: POST /api/v1/render
+2026-03-13T10:00:00.425Z INFO  [server] Starting HTTP server on :8080
+2026-03-13T10:00:00.427Z INFO  [server] Starting HTTPS server on :8443
+2026-03-13T10:00:00.430Z INFO  [server] Service ready, accepting connections
+2026-03-13T10:00:01.002Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:00:05.334Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:00:12.118Z INFO  [api] GET /api/v1/users/u-8831 200 14ms
+2026-03-13T10:00:12.119Z DEBUG [db] SELECT * FROM users WHERE id=$1 rows=1 duration=8ms
+2026-03-13T10:00:12.120Z DEBUG [cache] SET user:u-8831 ttl=300s size=1.2KB
+2026-03-13T10:00:15.005Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:00:18.441Z INFO  [api] POST /api/v1/render 200 45ms
+2026-03-13T10:00:18.442Z DEBUG [db] SELECT * FROM widgets WHERE project_id=$1 rows=12 duration=6ms
+2026-03-13T10:00:18.460Z DEBUG [cache] GET render:proj-221 HIT
+2026-03-13T10:00:25.003Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:00:27.812Z INFO  [api] GET /api/v1/projects/proj-221 200 22ms
+2026-03-13T10:00:27.813Z DEBUG [cache] GET project:proj-221 MISS
+2026-03-13T10:00:27.830Z DEBUG [db] SELECT * FROM projects WHERE id=$1 rows=1 duration=11ms
+2026-03-13T10:00:27.831Z DEBUG [cache] SET project:proj-221 ttl=300s size=3.4KB
+2026-03-13T10:00:33.119Z INFO  [worker] Worker-1 picked up job: email_notification job_id=job-40012
+2026-03-13T10:00:33.345Z DEBUG [worker] Rendering email template for user u-8831
+2026-03-13T10:00:33.567Z INFO  [worker] Job job-40012 completed in 448ms
+2026-03-13T10:00:35.004Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:00:41.200Z INFO  [api] GET /api/v1/widgets?page=1&limit=50 200 31ms
+2026-03-13T10:00:41.201Z DEBUG [db] SELECT * FROM widgets ORDER BY created_at DESC LIMIT 50 rows=50 duration=18ms
+2026-03-13T10:00:45.005Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:00:52.667Z INFO  [api] POST /api/v1/users 201 38ms
+2026-03-13T10:00:52.668Z DEBUG [db] INSERT INTO users (...) RETURNING id duration=24ms new_id=u-8842
+2026-03-13T10:00:52.670Z DEBUG [cache] DEL user_list:* invalidated=3
+2026-03-13T10:00:55.003Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:01:03.881Z WARN  [api] GET /api/v1/users/u-0000 404 3ms user_not_found
+2026-03-13T10:01:05.004Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:01:11.556Z INFO  [api] GET /api/v1/projects/proj-102 200 18ms
+2026-03-13T10:01:11.557Z DEBUG [cache] GET project:proj-102 HIT
+2026-03-13T10:01:15.005Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:01:22.334Z INFO  [api] POST /api/v1/render 200 62ms
+2026-03-13T10:01:22.335Z DEBUG [cache] GET render:proj-102 MISS
+2026-03-13T10:01:22.390Z DEBUG [db] SELECT * FROM widgets WHERE project_id=$1 rows=24 duration=19ms
+2026-03-13T10:01:22.391Z DEBUG [cache] SET render:proj-102 ttl=60s size=8.7KB
+2026-03-13T10:01:25.003Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:01:31.789Z WARN  [auth] Failed login attempt for user admin@example.com from 198.51.100.14
+2026-03-13T10:01:31.790Z DEBUG [auth] Incrementing failed_attempts counter for admin@example.com count=1
+2026-03-13T10:01:35.005Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:01:42.005Z INFO  [api] GET /api/v1/users/u-8842 200 9ms
+2026-03-13T10:01:42.006Z DEBUG [cache] GET user:u-8842 HIT
+2026-03-13T10:01:45.003Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:01:51.223Z INFO  [worker] Worker-3 picked up job: report_generation job_id=job-40013
+2026-03-13T10:01:51.224Z DEBUG [worker] Querying report data for project proj-221
+2026-03-13T10:01:51.890Z DEBUG [db] SELECT ... FROM analytics WHERE project_id=$1 AND date >= $2 rows=365 duration=620ms
+2026-03-13T10:01:52.112Z INFO  [worker] Job job-40013 completed in 889ms
+2026-03-13T10:01:55.004Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:02:03.445Z INFO  [api] GET /api/v1/widgets?page=2&limit=50 200 27ms
+2026-03-13T10:02:03.446Z DEBUG [db] SELECT * FROM widgets ORDER BY created_at DESC LIMIT 50 OFFSET 50 rows=50 duration=15ms
+2026-03-13T10:02:05.005Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:02:14.778Z WARN  [cache] High memory usage on Redis node cache-2: 82% of max_memory
+2026-03-13T10:02:15.003Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:02:22.001Z INFO  [api] POST /api/v1/projects 201 55ms
+2026-03-13T10:02:22.002Z DEBUG [db] INSERT INTO projects (...) RETURNING id duration=34ms new_id=proj-334
+2026-03-13T10:02:22.004Z DEBUG [cache] DEL project_list:* invalidated=5
+2026-03-13T10:02:25.004Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:02:33.119Z WARN  [auth] Failed login attempt for user admin@example.com from 198.51.100.14
+2026-03-13T10:02:33.120Z DEBUG [auth] Incrementing failed_attempts counter for admin@example.com count=2
+2026-03-13T10:02:35.005Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:02:44.890Z INFO  [api] GET /api/v1/users/u-7712 200 16ms
+2026-03-13T10:02:44.891Z DEBUG [cache] GET user:u-7712 MISS
+2026-03-13T10:02:44.903Z DEBUG [db] SELECT * FROM users WHERE id=$1 rows=1 duration=9ms
+2026-03-13T10:02:44.904Z DEBUG [cache] SET user:u-7712 ttl=300s size=1.1KB
+2026-03-13T10:02:45.003Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:02:55.334Z INFO  [api] POST /api/v1/render 200 41ms
+2026-03-13T10:02:55.335Z DEBUG [cache] GET render:proj-334 MISS
+2026-03-13T10:02:55.370Z DEBUG [db] SELECT * FROM widgets WHERE project_id=$1 rows=0 duration=5ms
+2026-03-13T10:02:55.371Z DEBUG [cache] SET render:proj-334 ttl=60s size=0.2KB
+2026-03-13T10:02:55.372Z WARN  [api] POST /api/v1/render project proj-334 has no widgets, returning empty layout
+2026-03-13T10:03:05.004Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:03:12.556Z INFO  [worker] Worker-0 picked up job: thumbnail_generation job_id=job-40014
+2026-03-13T10:03:12.557Z DEBUG [worker] Resizing image asset-99102 to 256x256
+2026-03-13T10:03:13.221Z INFO  [worker] Job job-40014 completed in 665ms
+2026-03-13T10:03:15.005Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:03:22.778Z WARN  [auth] Failed login attempt for user admin@example.com from 198.51.100.14
+2026-03-13T10:03:22.779Z WARN  [auth] Account admin@example.com locked after 3 failed attempts, lockout=300s
+2026-03-13T10:03:25.003Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:03:33.001Z INFO  [api] GET /api/v1/projects/proj-334 200 11ms
+2026-03-13T10:03:33.002Z DEBUG [cache] GET project:proj-334 HIT
+2026-03-13T10:03:35.005Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:03:44.223Z INFO  [api] GET /api/v1/users/u-8831 200 4ms
+2026-03-13T10:03:44.224Z DEBUG [cache] GET user:u-8831 HIT
+2026-03-13T10:03:45.003Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:03:55.112Z INFO  [api] POST /api/v1/render 200 39ms
+2026-03-13T10:03:55.113Z DEBUG [cache] GET render:proj-221 HIT
+2026-03-13T10:04:05.004Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:04:12.667Z WARN  [db] Slow query detected: SELECT ... FROM analytics duration=1204ms threshold=1000ms
+2026-03-13T10:04:12.668Z DEBUG [db] Query plan: Seq Scan on analytics, rows_estimated=50000, rows_actual=48712
+2026-03-13T10:04:15.005Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:04:24.890Z INFO  [api] GET /api/v1/widgets?filter=type:button 200 19ms
+2026-03-13T10:04:24.891Z DEBUG [db] SELECT * FROM widgets WHERE type=$1 rows=18 duration=10ms
+2026-03-13T10:04:25.003Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:04:33.778Z INFO  [worker] Worker-2 picked up job: webhook_delivery job_id=job-40015
+2026-03-13T10:04:33.779Z DEBUG [worker] Delivering webhook to https://hooks.client.example/events
+2026-03-13T10:04:34.112Z INFO  [worker] Job job-40015 completed in 333ms status=delivered
+2026-03-13T10:04:35.004Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:04:44.556Z INFO  [api] POST /api/v1/users 201 42ms
+2026-03-13T10:04:44.557Z DEBUG [db] INSERT INTO users (...) RETURNING id duration=28ms new_id=u-8843
+2026-03-13T10:04:45.005Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:04:55.223Z WARN  [cache] Connection to cache-1 timed out, retrying
+2026-03-13T10:04:55.445Z INFO  [cache] Reconnected to cache-1 after 222ms
+2026-03-13T10:05:05.003Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:05:12.334Z INFO  [api] GET /api/v1/projects/proj-102 200 6ms
+2026-03-13T10:05:12.335Z DEBUG [cache] GET project:proj-102 HIT
+2026-03-13T10:05:15.004Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:05:22.889Z INFO  [api] POST /api/v1/render 200 88ms
+2026-03-13T10:05:22.890Z DEBUG [cache] GET render:proj-102 MISS
+2026-03-13T10:05:22.960Z DEBUG [db] SELECT * FROM widgets WHERE project_id=$1 rows=24 duration=22ms
+2026-03-13T10:05:22.970Z DEBUG [cache] SET render:proj-102 ttl=60s size=8.7KB
+2026-03-13T10:05:25.005Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:05:35.112Z INFO  [api] GET /api/v1/users/u-8843 200 12ms
+2026-03-13T10:05:35.113Z DEBUG [cache] GET user:u-8843 MISS
+2026-03-13T10:05:35.121Z DEBUG [db] SELECT * FROM users WHERE id=$1 rows=1 duration=6ms
+2026-03-13T10:05:35.122Z DEBUG [cache] SET user:u-8843 ttl=300s size=1.0KB
+2026-03-13T10:05:45.003Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:05:52.445Z WARN  [api] GET /api/v1/projects/proj-999 404 4ms project_not_found
+2026-03-13T10:05:55.005Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:06:04.112Z INFO  [worker] Worker-1 picked up job: email_notification job_id=job-40016
+2026-03-13T10:06:04.334Z DEBUG [worker] Rendering email template for user u-8843
+2026-03-13T10:06:04.556Z INFO  [worker] Job job-40016 completed in 444ms
+2026-03-13T10:06:05.004Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:06:15.778Z INFO  [api] GET /api/v1/widgets?page=1&limit=25 200 14ms
+2026-03-13T10:06:15.779Z DEBUG [db] SELECT * FROM widgets ORDER BY created_at DESC LIMIT 25 rows=25 duration=8ms
+2026-03-13T10:06:25.003Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:06:33.223Z INFO  [api] POST /api/v1/render 200 51ms
+2026-03-13T10:06:33.224Z DEBUG [cache] GET render:proj-334 MISS
+2026-03-13T10:06:33.268Z DEBUG [db] SELECT * FROM widgets WHERE project_id=$1 rows=3 duration=7ms
+2026-03-13T10:06:33.269Z DEBUG [cache] SET render:proj-334 ttl=60s size=1.8KB
+2026-03-13T10:06:35.005Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:06:44.667Z WARN  [db] Connection pool utilization at 85% (17/20 active)
+2026-03-13T10:06:45.003Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:06:55.112Z INFO  [api] GET /api/v1/users/u-7712 200 3ms
+2026-03-13T10:06:55.113Z DEBUG [cache] GET user:u-7712 HIT
+2026-03-13T10:07:05.005Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:07:14.889Z INFO  [api] POST /api/v1/projects 201 48ms
+2026-03-13T10:07:14.890Z DEBUG [db] INSERT INTO projects (...) RETURNING id duration=29ms new_id=proj-335
+2026-03-13T10:07:14.892Z DEBUG [cache] DEL project_list:* invalidated=5
+2026-03-13T10:07:15.003Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:07:25.445Z INFO  [api] GET /api/v1/projects/proj-335 200 15ms
+2026-03-13T10:07:25.446Z DEBUG [cache] GET project:proj-335 MISS
+2026-03-13T10:07:25.457Z DEBUG [db] SELECT * FROM projects WHERE id=$1 rows=1 duration=8ms
+2026-03-13T10:07:25.458Z DEBUG [cache] SET project:proj-335 ttl=300s size=2.9KB
+2026-03-13T10:07:35.004Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:07:44.223Z INFO  [worker] Worker-3 picked up job: index_rebuild job_id=job-40017
+2026-03-13T10:07:44.224Z DEBUG [worker] Rebuilding search index for project proj-221
+2026-03-13T10:07:46.778Z DEBUG [db] SELECT * FROM widgets WHERE project_id=$1 rows=12 duration=14ms
+2026-03-13T10:07:47.112Z INFO  [worker] Job job-40017 completed in 2889ms
+2026-03-13T10:07:55.005Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:08:04.667Z INFO  [api] GET /api/v1/widgets?filter=type:input 200 16ms
+2026-03-13T10:08:04.668Z DEBUG [db] SELECT * FROM widgets WHERE type=$1 rows=9 duration=7ms
+2026-03-13T10:08:05.003Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:08:15.334Z WARN  [api] Request rate limit approaching for client api-key-8812: 450/500 rpm
+2026-03-13T10:08:25.004Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:08:33.556Z INFO  [api] POST /api/v1/render 200 37ms
+2026-03-13T10:08:33.557Z DEBUG [cache] GET render:proj-335 MISS
+2026-03-13T10:08:33.588Z DEBUG [db] SELECT * FROM widgets WHERE project_id=$1 rows=0 duration=4ms
+2026-03-13T10:08:33.589Z WARN  [api] POST /api/v1/render project proj-335 has no widgets, returning empty layout
+2026-03-13T10:08:35.005Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:08:45.112Z INFO  [api] GET /api/v1/users/u-8831 200 4ms
+2026-03-13T10:08:45.113Z DEBUG [cache] GET user:u-8831 HIT
+2026-03-13T10:08:55.003Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:09:05.778Z INFO  [api] POST /api/v1/users 201 35ms
+2026-03-13T10:09:05.779Z DEBUG [db] INSERT INTO users (...) RETURNING id duration=21ms new_id=u-8844
+2026-03-13T10:09:15.005Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:09:25.334Z WARN  [cache] Evicting stale entries: removed=142 freed=18.4MB
+2026-03-13T10:09:35.003Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:09:44.001Z INFO  [api] GET /api/v1/projects/proj-221 200 5ms
+2026-03-13T10:09:44.002Z DEBUG [cache] GET project:proj-221 HIT
+2026-03-13T10:09:55.004Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:10:03.889Z INFO  [worker] Worker-0 picked up job: webhook_delivery job_id=job-40018
+2026-03-13T10:10:03.890Z DEBUG [worker] Delivering webhook to https://hooks.client2.example/callbacks
+2026-03-13T10:10:04.567Z WARN  [worker] Webhook delivery attempt 1 failed for job-40018: connection refused
+2026-03-13T10:10:05.005Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:10:06.568Z DEBUG [worker] Retrying webhook delivery for job-40018 attempt=2
+2026-03-13T10:10:07.223Z WARN  [worker] Webhook delivery attempt 2 failed for job-40018: connection refused
+2026-03-13T10:10:09.224Z DEBUG [worker] Retrying webhook delivery for job-40018 attempt=3
+2026-03-13T10:10:09.890Z INFO  [worker] Job job-40018 completed in 6001ms status=delivered
+2026-03-13T10:10:15.003Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:10:25.445Z INFO  [api] POST /api/v1/render 200 43ms
+2026-03-13T10:10:25.446Z DEBUG [cache] GET render:proj-221 HIT
+2026-03-13T10:10:35.005Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:10:44.223Z INFO  [api] GET /api/v1/widgets?page=1&limit=50 200 29ms
+2026-03-13T10:10:44.224Z DEBUG [db] SELECT * FROM widgets ORDER BY created_at DESC LIMIT 50 rows=50 duration=16ms
+2026-03-13T10:10:55.003Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:11:04.112Z INFO  [api] GET /api/v1/users/u-8844 200 11ms
+2026-03-13T10:11:04.113Z DEBUG [cache] GET user:u-8844 MISS
+2026-03-13T10:11:04.120Z DEBUG [db] SELECT * FROM users WHERE id=$1 rows=1 duration=5ms
+2026-03-13T10:11:04.121Z DEBUG [cache] SET user:u-8844 ttl=300s size=1.1KB
+2026-03-13T10:11:15.004Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:11:22.889Z WARN  [db] Connection pool utilization at 90% (18/20 active)
+2026-03-13T10:11:25.005Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:11:33.667Z INFO  [api] POST /api/v1/render 200 55ms
+2026-03-13T10:11:33.668Z DEBUG [cache] GET render:proj-102 MISS
+2026-03-13T10:11:33.715Z DEBUG [db] SELECT * FROM widgets WHERE project_id=$1 rows=24 duration=20ms
+2026-03-13T10:11:33.716Z DEBUG [cache] SET render:proj-102 ttl=60s size=8.7KB
+2026-03-13T10:11:35.003Z INFO  [api] GET /api/v1/health 200 2ms caller=k8s-probe
+2026-03-13T10:11:44.334Z INFO  [api] GET /api/v1/projects/proj-335 200 4ms
+2026-03-13T10:11:44.335Z DEBUG [cache] GET project:proj-335 HIT
+2026-03-13T10:11:55.004Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:12:00.001Z INFO  [db] Connection pool stats: active=12 idle=8 wait_count=0 avg_wait=0ms
+2026-03-13T10:12:04.556Z INFO  [api] GET /api/v1/users/u-7712 200 3ms
+2026-03-13T10:12:04.557Z DEBUG [cache] GET user:u-7712 HIT
+2026-03-13T10:12:05.005Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:12:15.223Z INFO  [worker] Worker-2 picked up job: data_export job_id=job-40019
+2026-03-13T10:12:15.224Z DEBUG [worker] Exporting data for project proj-102 format=csv
+2026-03-13T10:12:17.890Z DEBUG [db] SELECT * FROM events WHERE project_id=$1 rows=12480 duration=2100ms
+2026-03-13T10:12:18.556Z INFO  [worker] Job job-40019 completed in 3332ms exported_rows=12480
+2026-03-13T10:12:25.003Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:12:34.001Z INFO  [api] POST /api/v1/render 200 40ms
+2026-03-13T10:12:34.002Z DEBUG [cache] GET render:proj-335 MISS
+2026-03-13T10:12:34.036Z DEBUG [db] SELECT * FROM widgets WHERE project_id=$1 rows=3 duration=6ms
+2026-03-13T10:12:34.037Z DEBUG [cache] SET render:proj-335 ttl=60s size=1.8KB
+2026-03-13T10:12:35.004Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:12:44.778Z WARN  [api] Request timeout for GET /api/v1/widgets?filter=complex_query duration=5001ms
+2026-03-13T10:12:45.005Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:12:55.112Z INFO  [api] GET /api/v1/projects/proj-221 200 5ms
+2026-03-13T10:12:55.113Z DEBUG [cache] GET project:proj-221 HIT
+2026-03-13T10:13:05.003Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:13:14.667Z INFO  [api] POST /api/v1/users 201 38ms
+2026-03-13T10:13:14.668Z DEBUG [db] INSERT INTO users (...) RETURNING id duration=24ms new_id=u-8845
+2026-03-13T10:13:15.004Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:13:25.445Z INFO  [api] GET /api/v1/users/u-8845 200 13ms
+2026-03-13T10:13:25.446Z DEBUG [cache] GET user:u-8845 MISS
+2026-03-13T10:13:25.455Z DEBUG [db] SELECT * FROM users WHERE id=$1 rows=1 duration=7ms
+2026-03-13T10:13:25.456Z DEBUG [cache] SET user:u-8845 ttl=300s size=1.2KB
+2026-03-13T10:13:35.005Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:14:00.001Z INFO  [server] Periodic stats: requests_total=187 avg_latency=23ms p99_latency=88ms errors=2
+2026-03-13T10:14:05.003Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:14:14.889Z INFO  [api] POST /api/v1/render 200 44ms
+2026-03-13T10:14:14.890Z DEBUG [cache] GET render:proj-221 HIT
+2026-03-13T10:14:25.004Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:14:33.112Z INFO  [api] GET /api/v1/widgets?filter=type:chart 200 21ms
+2026-03-13T10:14:33.113Z DEBUG [db] SELECT * FROM widgets WHERE type=$1 rows=7 duration=11ms
+2026-03-13T10:14:35.005Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:14:44.556Z INFO  [worker] Worker-1 picked up job: email_notification job_id=job-40020
+2026-03-13T10:14:44.557Z DEBUG [worker] Rendering email template for user u-8845
+2026-03-13T10:14:44.890Z INFO  [worker] Job job-40020 completed in 333ms
+2026-03-13T10:14:55.003Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:15:04.223Z INFO  [api] GET /api/v1/projects/proj-102 200 5ms
+2026-03-13T10:15:04.224Z DEBUG [cache] GET project:proj-102 HIT
+2026-03-13T10:15:15.005Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:15:25.667Z WARN  [auth] Token refresh failed for session sess-44210: token expired 120s ago
+2026-03-13T10:15:25.668Z DEBUG [auth] Forcing re-authentication for session sess-44210
+2026-03-13T10:15:35.003Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:15:44.001Z INFO  [api] POST /api/v1/render 200 52ms
+2026-03-13T10:15:44.002Z DEBUG [cache] GET render:proj-102 MISS
+2026-03-13T10:15:44.048Z DEBUG [db] SELECT * FROM widgets WHERE project_id=$1 rows=24 duration=18ms
+2026-03-13T10:15:44.049Z DEBUG [cache] SET render:proj-102 ttl=60s size=8.7KB
+2026-03-13T10:15:55.004Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:16:05.778Z INFO  [api] GET /api/v1/users/u-8842 200 3ms
+2026-03-13T10:16:05.779Z DEBUG [cache] GET user:u-8842 HIT
+2026-03-13T10:16:15.005Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:16:25.112Z INFO  [api] GET /api/v1/widgets?page=3&limit=50 200 28ms
+2026-03-13T10:16:25.113Z DEBUG [db] SELECT * FROM widgets ORDER BY created_at DESC LIMIT 50 OFFSET 100 rows=43 duration=14ms
+2026-03-13T10:16:35.003Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:16:44.890Z INFO  [worker] Worker-3 picked up job: report_generation job_id=job-40021
+2026-03-13T10:16:44.891Z DEBUG [worker] Querying report data for project proj-335
+2026-03-13T10:16:45.334Z DEBUG [db] SELECT ... FROM analytics WHERE project_id=$1 AND date >= $2 rows=45 duration=380ms
+2026-03-13T10:16:45.556Z INFO  [worker] Job job-40021 completed in 665ms
+2026-03-13T10:16:55.005Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:17:05.445Z INFO  [api] POST /api/v1/render 200 38ms
+2026-03-13T10:17:05.446Z DEBUG [cache] GET render:proj-334 MISS
+2026-03-13T10:17:05.478Z DEBUG [db] SELECT * FROM widgets WHERE project_id=$1 rows=3 duration=5ms
+2026-03-13T10:17:05.479Z DEBUG [cache] SET render:proj-334 ttl=60s size=1.8KB
+2026-03-13T10:17:15.003Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:17:25.223Z WARN  [cache] High memory usage on Redis node cache-2: 87% of max_memory
+2026-03-13T10:17:35.004Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:17:44.778Z INFO  [api] GET /api/v1/projects/proj-334 200 4ms
+2026-03-13T10:17:44.779Z DEBUG [cache] GET project:proj-334 HIT
+2026-03-13T10:17:55.005Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:18:04.112Z INFO  [api] GET /api/v1/users/u-8831 200 3ms
+2026-03-13T10:18:04.113Z DEBUG [cache] GET user:u-8831 HIT
+2026-03-13T10:18:15.003Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:18:25.889Z INFO  [api] POST /api/v1/projects 201 52ms
+2026-03-13T10:18:25.890Z DEBUG [db] INSERT INTO projects (...) RETURNING id duration=33ms new_id=proj-336
+2026-03-13T10:18:25.892Z DEBUG [cache] DEL project_list:* invalidated=6
+2026-03-13T10:18:35.005Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:18:45.556Z INFO  [api] POST /api/v1/render 200 41ms
+2026-03-13T10:18:45.557Z DEBUG [cache] GET render:proj-336 MISS
+2026-03-13T10:18:45.592Z DEBUG [db] SELECT * FROM widgets WHERE project_id=$1 rows=0 duration=4ms
+2026-03-13T10:18:45.593Z WARN  [api] POST /api/v1/render project proj-336 has no widgets, returning empty layout
+2026-03-13T10:18:55.003Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:19:05.223Z INFO  [worker] Worker-0 picked up job: thumbnail_generation job_id=job-40022
+2026-03-13T10:19:05.224Z DEBUG [worker] Resizing image asset-99210 to 256x256
+2026-03-13T10:19:05.890Z INFO  [worker] Job job-40022 completed in 667ms
+2026-03-13T10:19:15.004Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:19:25.778Z INFO  [api] GET /api/v1/widgets?filter=type:table 200 18ms
+2026-03-13T10:19:25.779Z DEBUG [db] SELECT * FROM widgets WHERE type=$1 rows=5 duration=9ms
+2026-03-13T10:19:35.005Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:19:44.445Z INFO  [api] GET /api/v1/projects/proj-336 200 14ms
+2026-03-13T10:19:44.446Z DEBUG [cache] GET project:proj-336 MISS
+2026-03-13T10:19:44.456Z DEBUG [db] SELECT * FROM projects WHERE id=$1 rows=1 duration=7ms
+2026-03-13T10:19:44.457Z DEBUG [cache] SET project:proj-336 ttl=300s size=2.7KB
+2026-03-13T10:19:55.003Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:20:00.002Z INFO  [server] Periodic stats: requests_total=312 avg_latency=21ms p99_latency=82ms errors=3
+2026-03-13T10:20:04.667Z INFO  [api] POST /api/v1/render 200 46ms
+2026-03-13T10:20:04.668Z DEBUG [cache] GET render:proj-221 HIT
+2026-03-13T10:20:15.005Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:20:25.001Z INFO  [api] GET /api/v1/users/u-8844 200 4ms
+2026-03-13T10:20:25.002Z DEBUG [cache] GET user:u-8844 HIT
+2026-03-13T10:20:35.003Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:20:44.334Z WARN  [db] Slow query detected: SELECT ... FROM widgets JOIN projects duration=1102ms threshold=1000ms
+2026-03-13T10:20:55.004Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:21:05.112Z INFO  [api] POST /api/v1/users 201 36ms
+2026-03-13T10:21:05.113Z DEBUG [db] INSERT INTO users (...) RETURNING id duration=22ms new_id=u-8846
+2026-03-13T10:21:15.005Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:21:25.445Z INFO  [worker] Worker-2 picked up job: webhook_delivery job_id=job-40023
+2026-03-13T10:21:25.446Z DEBUG [worker] Delivering webhook to https://hooks.client.example/events
+2026-03-13T10:21:25.890Z INFO  [worker] Job job-40023 completed in 444ms status=delivered
+2026-03-13T10:21:35.003Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:21:44.778Z INFO  [api] GET /api/v1/projects/proj-221 200 5ms
+2026-03-13T10:21:44.779Z DEBUG [cache] GET project:proj-221 HIT
+2026-03-13T10:21:55.004Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:22:04.556Z INFO  [api] GET /api/v1/widgets?page=1&limit=50 200 30ms
+2026-03-13T10:22:04.557Z DEBUG [db] SELECT * FROM widgets ORDER BY created_at DESC LIMIT 50 rows=50 duration=17ms
+2026-03-13T10:22:15.005Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:22:25.667Z INFO  [api] POST /api/v1/render 200 48ms
+2026-03-13T10:22:25.668Z DEBUG [cache] GET render:proj-102 MISS
+2026-03-13T10:22:25.710Z DEBUG [db] SELECT * FROM widgets WHERE project_id=$1 rows=24 duration=19ms
+2026-03-13T10:22:25.711Z DEBUG [cache] SET render:proj-102 ttl=60s size=8.7KB
+2026-03-13T10:22:35.003Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:22:44.223Z WARN  [cache] Connection to cache-3 timed out, retrying
+2026-03-13T10:22:44.556Z WARN  [cache] Reconnection attempt 1 to cache-3 failed
+2026-03-13T10:22:45.557Z WARN  [cache] Reconnection attempt 2 to cache-3 failed
+2026-03-13T10:22:46.890Z INFO  [cache] Reconnected to cache-3 after 2667ms
+2026-03-13T10:22:46.891Z WARN  [cache] cache-3 was unreachable for 2.6s, some cache reads may have been served from other nodes
+2026-03-13T10:22:55.004Z INFO  [api] GET /api/v1/health 200 2ms caller=k8s-probe
+2026-03-13T10:23:05.005Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:23:14.112Z INFO  [api] GET /api/v1/users/u-8846 200 12ms
+2026-03-13T10:23:14.113Z DEBUG [cache] GET user:u-8846 MISS
+2026-03-13T10:23:14.121Z DEBUG [db] SELECT * FROM users WHERE id=$1 rows=1 duration=6ms
+2026-03-13T10:23:14.122Z DEBUG [cache] SET user:u-8846 ttl=300s size=1.0KB
+2026-03-13T10:23:25.003Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:23:35.890Z INFO  [api] POST /api/v1/render 200 39ms
+2026-03-13T10:23:35.891Z DEBUG [cache] GET render:proj-336 MISS
+2026-03-13T10:23:35.924Z DEBUG [db] SELECT * FROM widgets WHERE project_id=$1 rows=2 duration=5ms
+2026-03-13T10:23:35.925Z DEBUG [cache] SET render:proj-336 ttl=60s size=1.2KB
+2026-03-13T10:23:45.005Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:23:55.334Z INFO  [worker] Worker-1 picked up job: email_notification job_id=job-40024
+2026-03-13T10:23:55.335Z DEBUG [worker] Rendering email template for user u-8846
+2026-03-13T10:23:55.667Z INFO  [worker] Job job-40024 completed in 332ms
+2026-03-13T10:24:05.003Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:24:15.778Z INFO  [api] GET /api/v1/projects/proj-335 200 4ms
+2026-03-13T10:24:15.779Z DEBUG [cache] GET project:proj-335 HIT
+2026-03-13T10:24:25.004Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:24:34.556Z INFO  [api] GET /api/v1/users/u-7712 200 3ms
+2026-03-13T10:24:34.557Z DEBUG [cache] GET user:u-7712 HIT
+2026-03-13T10:24:45.005Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:24:55.001Z INFO  [api] POST /api/v1/render 200 42ms
+2026-03-13T10:24:55.002Z DEBUG [cache] GET render:proj-221 HIT
+2026-03-13T10:25:05.003Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:25:14.445Z WARN  [api] Request rate limit approaching for client api-key-9001: 480/500 rpm
+2026-03-13T10:25:25.004Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:25:35.112Z INFO  [api] GET /api/v1/widgets?filter=type:text 200 15ms
+2026-03-13T10:25:35.113Z DEBUG [db] SELECT * FROM widgets WHERE type=$1 rows=22 duration=8ms
+2026-03-13T10:25:45.005Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:25:55.667Z INFO  [api] POST /api/v1/projects 201 50ms
+2026-03-13T10:25:55.668Z DEBUG [db] INSERT INTO projects (...) RETURNING id duration=31ms new_id=proj-337
+2026-03-13T10:25:55.670Z DEBUG [cache] DEL project_list:* invalidated=7
+2026-03-13T10:26:00.001Z INFO  [server] Periodic stats: requests_total=438 avg_latency=20ms p99_latency=78ms errors=3
+2026-03-13T10:26:05.003Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:26:15.778Z INFO  [api] GET /api/v1/projects/proj-337 200 13ms
+2026-03-13T10:26:15.779Z DEBUG [cache] GET project:proj-337 MISS
+2026-03-13T10:26:15.788Z DEBUG [db] SELECT * FROM projects WHERE id=$1 rows=1 duration=6ms
+2026-03-13T10:26:15.789Z DEBUG [cache] SET project:proj-337 ttl=300s size=2.8KB
+2026-03-13T10:26:25.004Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:26:35.445Z INFO  [worker] Worker-3 picked up job: data_export job_id=job-40025
+2026-03-13T10:26:35.446Z DEBUG [worker] Exporting data for project proj-221 format=json
+2026-03-13T10:26:38.001Z DEBUG [db] SELECT * FROM events WHERE project_id=$1 rows=18920 duration=2200ms
+2026-03-13T10:26:38.890Z INFO  [worker] Job job-40025 completed in 3444ms exported_rows=18920
+2026-03-13T10:26:45.005Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:26:55.112Z INFO  [api] POST /api/v1/render 200 44ms
+2026-03-13T10:26:55.113Z DEBUG [cache] GET render:proj-335 MISS
+2026-03-13T10:26:55.151Z DEBUG [db] SELECT * FROM widgets WHERE project_id=$1 rows=5 duration=9ms
+2026-03-13T10:26:55.152Z DEBUG [cache] SET render:proj-335 ttl=60s size=3.1KB
+2026-03-13T10:27:05.003Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:27:15.890Z INFO  [api] GET /api/v1/users/u-8845 200 4ms
+2026-03-13T10:27:15.891Z DEBUG [cache] GET user:u-8845 HIT
+2026-03-13T10:27:25.004Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:27:35.223Z INFO  [api] POST /api/v1/render 200 40ms
+2026-03-13T10:27:35.224Z DEBUG [cache] GET render:proj-336 MISS
+2026-03-13T10:27:35.258Z DEBUG [db] SELECT * FROM widgets WHERE project_id=$1 rows=2 duration=5ms
+2026-03-13T10:27:35.259Z DEBUG [cache] SET render:proj-336 ttl=60s size=1.2KB
+2026-03-13T10:27:45.005Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:27:55.556Z WARN  [db] Slow query detected: SELECT DISTINCT ... FROM widgets JOIN analytics duration=1550ms threshold=1000ms
+2026-03-13T10:28:05.003Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:28:14.334Z INFO  [api] GET /api/v1/widgets?page=1&limit=100 200 35ms
+2026-03-13T10:28:14.335Z DEBUG [db] SELECT * FROM widgets ORDER BY created_at DESC LIMIT 100 rows=96 duration=21ms
+2026-03-13T10:28:25.005Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:28:35.778Z INFO  [api] GET /api/v1/projects/proj-102 200 4ms
+2026-03-13T10:28:35.779Z DEBUG [cache] GET project:proj-102 HIT
+2026-03-13T10:28:45.003Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:28:55.112Z INFO  [api] POST /api/v1/render 200 53ms
+2026-03-13T10:28:55.113Z DEBUG [cache] GET render:proj-102 MISS
+2026-03-13T10:28:55.160Z DEBUG [db] SELECT * FROM widgets WHERE project_id=$1 rows=24 duration=20ms
+2026-03-13T10:28:55.161Z DEBUG [cache] SET render:proj-102 ttl=60s size=8.7KB
+2026-03-13T10:29:05.004Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:29:14.667Z INFO  [worker] Worker-0 picked up job: index_rebuild job_id=job-40026
+2026-03-13T10:29:14.668Z DEBUG [worker] Rebuilding search index for project proj-335
+2026-03-13T10:29:16.890Z DEBUG [db] SELECT * FROM widgets WHERE project_id=$1 rows=5 duration=10ms
+2026-03-13T10:29:17.223Z INFO  [worker] Job job-40026 completed in 2555ms
+2026-03-13T10:29:25.005Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:29:35.445Z INFO  [api] GET /api/v1/users/u-8843 200 3ms
+2026-03-13T10:29:35.446Z DEBUG [cache] GET user:u-8843 HIT
+2026-03-13T10:29:45.003Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:29:55.334Z INFO  [api] POST /api/v1/render 200 39ms
+2026-03-13T10:29:55.335Z DEBUG [cache] GET render:proj-221 HIT
+2026-03-13T10:30:00.003Z INFO  [db] Connection pool stats: active=10 idle=10 wait_count=0 avg_wait=0ms
+2026-03-13T10:30:05.004Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:30:15.001Z ERROR [db] Connection to db-primary.internal:5432 lost: read tcp 10.0.1.15:5432: i/o timeout
+2026-03-13T10:30:15.002Z ERROR [db] Active queries interrupted: 4 queries aborted
+2026-03-13T10:30:15.003Z WARN  [db] Initiating failover to db-replica.internal:5432
+2026-03-13T10:30:15.112Z INFO  [db] Attempting connection to db-replica.internal:5432
+2026-03-13T10:30:15.334Z INFO  [db] Connected to replica, verifying read/write capability
+2026-03-13T10:30:15.445Z ERROR [api] POST /api/v1/render 503 5012ms
+  database connection lost during query execution
+  github.com/joncooper/imagine-tui/internal/db.(*Pool).Query
+  	/app/internal/db/pool.go:142
+  github.com/joncooper/imagine-tui/internal/api.(*Handler).HandleRender
+  	/app/internal/api/render.go:87
+  github.com/joncooper/imagine-tui/internal/api.(*Router).ServeHTTP
+  	/app/internal/api/router.go:55
+  net/http.(*ServeMux).ServeHTTP
+  	/usr/local/go/src/net/http/server.go:2556
+2026-03-13T10:30:15.446Z ERROR [api] GET /api/v1/users/u-8831 503 4998ms
+  database connection lost during query execution
+  github.com/joncooper/imagine-tui/internal/db.(*Pool).Query
+  	/app/internal/db/pool.go:142
+  github.com/joncooper/imagine-tui/internal/api.(*Handler).GetUser
+  	/app/internal/api/users.go:34
+  github.com/joncooper/imagine-tui/internal/api.(*Router).ServeHTTP
+  	/app/internal/api/router.go:55
+  net/http.(*ServeMux).ServeHTTP
+  	/usr/local/go/src/net/http/server.go:2556
+2026-03-13T10:30:15.556Z ERROR [api] GET /api/v1/projects/proj-221 503 4890ms
+  database connection lost during query execution
+  github.com/joncooper/imagine-tui/internal/db.(*Pool).Query
+  	/app/internal/db/pool.go:142
+  github.com/joncooper/imagine-tui/internal/api.(*Handler).GetProject
+  	/app/internal/api/projects.go:41
+  github.com/joncooper/imagine-tui/internal/api.(*Router).ServeHTTP
+  	/app/internal/api/router.go:55
+  net/http.(*ServeMux).ServeHTTP
+  	/usr/local/go/src/net/http/server.go:2556
+2026-03-13T10:30:15.557Z ERROR [worker] Worker-2 job job-40027 failed: database connection lost
+2026-03-13T10:30:15.890Z INFO  [db] Replica promoted to primary, pool re-established, pool_size=20
+2026-03-13T10:30:15.891Z WARN  [db] 4 queries were lost during failover, clients should retry
+2026-03-13T10:30:16.001Z INFO  [api] GET /api/v1/health 200 3ms caller=k8s-probe
+2026-03-13T10:30:25.003Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:30:34.112Z INFO  [api] POST /api/v1/render 200 48ms
+2026-03-13T10:30:34.113Z DEBUG [cache] GET render:proj-221 MISS
+2026-03-13T10:30:34.155Z DEBUG [db] SELECT * FROM widgets WHERE project_id=$1 rows=12 duration=14ms
+2026-03-13T10:30:34.156Z DEBUG [cache] SET render:proj-221 ttl=60s size=5.4KB
+2026-03-13T10:30:35.004Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:30:44.556Z INFO  [api] GET /api/v1/users/u-8831 200 15ms
+2026-03-13T10:30:44.557Z DEBUG [cache] GET user:u-8831 MISS
+2026-03-13T10:30:44.568Z DEBUG [db] SELECT * FROM users WHERE id=$1 rows=1 duration=8ms
+2026-03-13T10:30:44.569Z DEBUG [cache] SET user:u-8831 ttl=300s size=1.2KB
+2026-03-13T10:30:55.005Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:31:05.334Z INFO  [api] GET /api/v1/projects/proj-221 200 16ms
+2026-03-13T10:31:05.335Z DEBUG [cache] GET project:proj-221 MISS
+2026-03-13T10:31:05.347Z DEBUG [db] SELECT * FROM projects WHERE id=$1 rows=1 duration=9ms
+2026-03-13T10:31:05.348Z DEBUG [cache] SET project:proj-221 ttl=300s size=3.4KB
+2026-03-13T10:31:15.003Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:31:25.778Z INFO  [api] POST /api/v1/users 201 37ms
+2026-03-13T10:31:25.779Z DEBUG [db] INSERT INTO users (...) RETURNING id duration=23ms new_id=u-8847
+2026-03-13T10:31:35.004Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:31:44.112Z INFO  [worker] Worker-1 picked up job: email_notification job_id=job-40028
+2026-03-13T10:31:44.113Z DEBUG [worker] Rendering email template for user u-8847
+2026-03-13T10:31:44.445Z INFO  [worker] Job job-40028 completed in 333ms
+2026-03-13T10:31:55.005Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:32:00.001Z INFO  [server] Periodic stats: requests_total=521 avg_latency=24ms p99_latency=102ms errors=7
+2026-03-13T10:32:05.003Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:32:14.667Z INFO  [api] GET /api/v1/widgets?filter=type:chart 200 19ms
+2026-03-13T10:32:14.668Z DEBUG [db] SELECT * FROM widgets WHERE type=$1 rows=7 duration=10ms
+2026-03-13T10:32:15.004Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe
+2026-03-13T10:32:25.890Z INFO  [api] GET /api/v1/users/u-8847 200 12ms
+2026-03-13T10:32:25.891Z DEBUG [cache] GET user:u-8847 MISS
+2026-03-13T10:32:25.899Z DEBUG [db] SELECT * FROM users WHERE id=$1 rows=1 duration=6ms
+2026-03-13T10:32:25.900Z DEBUG [cache] SET user:u-8847 ttl=300s size=1.1KB
+2026-03-13T10:32:35.005Z INFO  [api] GET /api/v1/health 200 1ms caller=k8s-probe

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -36,369 +36,126 @@ Current deferred files:
 
 ---
 
-## Milestone 0: Project skeleton & CI
+## Completed milestones
 
-**Goal**: Repo structure, build pipeline, dependency management, and the "hello world" of each layer wired together. Nothing works yet, but everything compiles and the test harness runs.
+### M0: Project skeleton & CI ✅
 
-### M0-1: Repository setup
-- Initialize Go module (`github.com/[org]/imagine-tui`)
-- Directory structure: `cmd/imagine-tui/`, `internal/dom/`, `internal/script/`, `internal/widget/`, `internal/mcp/`, `internal/render/`, `testdata/`
-- Makefile with `build`, `test`, `lint`, `golden-update` targets
-- `.golangci-lint.yml` with strict settings
-- CI pipeline (GitHub Actions): lint → test → build on every push
-- **No TDD here** — this is scaffolding
+Go module, directory structure, CI pipeline, dependency lock, test harness scaffolding.
+3 tickets, all complete.
 
-### M0-2: Dependency lock
-- Add dependencies: `charmbracelet/bubbletea`, `charmbracelet/lipgloss`, `charmbracelet/bubbles`, `dop251/goja`, MCP Go SDK (evaluate `mark3labs/mcp-go` or `modelcontextprotocol/go-sdk`)
-- Verify all compile. Write one trivial test per dependency to confirm import works.
-- Document version pins in README
+### M1: The DOM ✅
 
-### M0-3: Test harness scaffolding
-- Set up `testutil` package with helpers: `NewTestDOM()`, `MustPatch()`, `AssertNodeProps()`, `GoldenFile()`
-- Golden file infrastructure: `testdata/golden/` directory, `golden-update` make target, `GOLDEN_UPDATE=1` env var to regenerate
-- Confirm `go test ./...` passes with zero tests (no failures on empty)
+Node data structure, tree operations, patch engine, replace, query, snapshot/restore, event queue. Pure data, no rendering. TDD mandatory for every ticket.
+7 tickets, all complete. 95%+ coverage.
 
----
+### M2: MCP server ✅
 
-## Milestone 1: The DOM (pure data, no rendering)
+Server skeleton, 6 tools (patch, replace, await_event, snapshot, restore, query), error handling. Protocol layer atop DOM, no rendering.
+7 tickets, all complete.
 
-**Goal**: A fully functional DOM tree with all CRUD operations, tested exhaustively. This is the foundation everything else builds on. TDD is mandatory for every ticket in this milestone.
+### M3: Script runtime ✅
 
-### M1-1: Node data structure
-- **TDD**: Write tests first for node creation, ID uniqueness, type validation
-- Define `Node` struct: ID, Type, Props (map[string]any), Children (ordered slice), Scripts, Computed, parent pointer
-- Node constructor validates ID format (non-empty, no whitespace) and type against registry
-- Props are typed per widget type — start with a `PropSchema` interface, validate on set
-- **Tests**: creation, ID validation, type validation, prop type checking, deep equality
+goja sandbox, $ API (current node + cross-node), emit(), state, lifecycle hooks, computed props. TDD mandatory for $ API surface.
+7 tickets, all complete.
 
-### M1-2: Tree operations
-- **TDD**: Write tests for insert, remove, move, reparent, find-by-ID
-- `tree.Insert(parentID, node, afterID)` — insert child, optionally after a sibling
-- `tree.Remove(id)` — remove node and all descendants, return removed subtree
-- `tree.Move(id, newParentID, afterID)` — reparent atomically
-- `tree.Find(id)` — O(1) lookup via ID index (map[string]*Node maintained on mutations)
-- `tree.Walk(fn)` — depth-first traversal
-- `tree.Summary()` — compact string representation (e.g., `"root > header + main(form, table)"`)
-- **Tests**: all operations, including error paths (duplicate ID on insert, remove nonexistent, move to descendant of self, move creating cycle). Table-driven, minimum 30 test cases.
+### M4: Widget library (v1 core set) ✅
 
-### M1-3: Patch engine
-- **TDD**: Write tests for each op type, then for multi-op atomicity
-- Parse patch ops from JSON: `update`, `insert`, `remove`, `move`
-- Apply ops in order, atomically (all succeed or all roll back)
-- On `update`: merge props (not replace), merge scripts, merge computed
-- Validate all node IDs exist (or will exist after prior ops in the batch)
-- Return structured error with op index on failure
-- **Tests**: single ops, multi-op batches, rollback on failure, prop merging semantics, ID validation. Minimum 40 test cases.
+Registry, rendering pipeline, 11 v1 widgets (container, text, input, textarea, select, button, table, list, diff, log, code). 154 tests, all passing.
+12 tickets, all complete. Design doc: [docs/widget/DESIGN.md](widget/DESIGN.md). Deferred: [docs/widget/DEFERRED.md](widget/DEFERRED.md).
 
-### M1-4: Replace operation
-- **TDD**: Write tests for subtree replacement
-- `Replace(id, newTree)` — remove all children of target, insert new subtree
-- Validate no ID collisions between new subtree and existing tree (excluding the replaced subtree)
-- ID index is rebuilt for the affected subtree
-- **Tests**: full replacement, partial replacement, ID collision detection, nested replacement
+### M5: BubbleTea integration ✅
 
-### M1-5: Query operation
-- **TDD**: Write tests for state readback
-- `Query(ids []string)` — return props + local state for each requested node
-- Include computed values (evaluated at query time)
-- Return error for nonexistent IDs (partial success: return what exists, error on missing)
-- **Tests**: single node, multiple nodes, nonexistent node, computed prop evaluation at query time
-
-### M1-6: Snapshot & restore
-- **TDD**: Write tests for snapshot fidelity and restore correctness
-- `Snapshot(name)` — deep copy entire tree + ID index to named store
-- `Restore(name)` — replace current tree with deep copy of snapshot, rebuild ID index
-- Snapshot store is a `map[string]*TreeSnapshot`
-- Deep copy must handle all node fields including scripts (strings) and computed (strings)
-- **Tests**: snapshot, restore, restore-then-modify-doesn't-affect-snapshot, overwrite existing snapshot name, restore nonexistent name, multiple snapshots
-
-### M1-7: Event queue
-- **TDD**: Write tests for enqueue, dequeue, filtering, debouncing, timeout
-- Thread-safe queue (channel or mutex-guarded slice)
-- `Enqueue(event)` — add event with source node ID, event type, and auto-collected context
-- `Dequeue(opts)` — blocking dequeue with optional timeout, filter, debounce
-- Context auto-collection: when enqueueing, walk up to parent, collect sibling values
-- `dom_summary` generation from current tree state
-- **Tests**: basic enqueue/dequeue, timeout expiry, filter by node ID, debounce coalescing, concurrent enqueue from multiple goroutines, context auto-collection accuracy
+BubbleTea model & update loop, focus management (FocusRing with Tab/Shift-Tab, container trapping), MCP↔BubbleTea bridge (DOMChangedMsg, CallTool), terminal resize, startup & shutdown (stdio MCP + stderr BubbleTea alt screen, signal handling, broken pipe detection). 43 tests, 88% coverage on render package.
+5 tickets, all complete.
 
 ---
 
-## Milestone 2: MCP server (protocol layer, no rendering)
-
-**Goal**: A working MCP server that accepts tool calls over stdio, routes them to the DOM layer, and returns proper JSON-RPC responses. Tested against the MCP protocol spec. TDD is mandatory.
-
-### M2-1: MCP server skeleton
-- **TDD**: Write protocol-level tests first (send JSON-RPC, assert response shape)
-- Initialize MCP server with tool declarations: `patch`, `replace`, `await_event`, `snapshot`, `restore`, `query`
-- Tool schemas defined as JSON Schema (these become the contract Claude Code sees)
-- Server reads from stdin, writes to stdout (stdio transport)
-- **Tests**: server starts, responds to `initialize`, lists tools, handles unknown tool name
-
-### M2-2: Tool: patch
-- **TDD**: Write MCP-level tests (JSON-RPC call → response)
-- Parse tool input, validate against schema, call DOM patch engine
-- Return `{ ok: true }` or structured error
-- **Tests**: valid patch, invalid JSON, missing required fields, patch engine error passthrough
-
-### M2-3: Tool: replace
-- Same pattern as M2-2 but for replace
-- **Tests**: valid replace, ID not found, ID collision in new tree
-
-### M2-4: Tool: await_event
-- **TDD**: Write tests for the long-poll lifecycle
-- Tool call blocks until event queue has an event (or timeout)
-- Parse optional parameters: `timeout_ms`, `filter`, `debounce_ms`
-- Return event payload with context and dom_summary
-- **Tests**: event fires before call (immediate return), event fires after call (blocked then returns), timeout, filter, debounce, multiple rapid events
-
-### M2-5: Tool: snapshot & restore
-- Thin wrappers around DOM snapshot/restore
-- **Tests**: round-trip via MCP, error on nonexistent snapshot name
-
-### M2-6: Tool: query
-- Thin wrapper around DOM query
-- **Tests**: existing nodes, missing nodes, computed prop evaluation via MCP
-
-### M2-7: MCP error handling & edge cases
-- Handle malformed JSON-RPC
-- Handle tool calls during server shutdown
-- Handle concurrent tool calls (should await_event and patch be serialized? Probably yes — document the decision)
-- **Tests**: malformed input, concurrent calls, shutdown mid-await
+## Active milestones
 
 ---
 
-## Milestone 3: Script runtime (goja integration)
+### Milestone 6: End-to-end demo — log viewer
 
-**Goal**: Claude-authored scripts execute against the DOM, the $ API works, computed props re-evaluate reactively. TDD is mandatory for the $ API surface.
+**Goal**: The first reference demo runs end-to-end. Validates the full stack: MCP → DOM → scripts → widgets → terminal. A user opens a separate Claude Code session, prompts "build me a log viewer," and Claude Code constructs the TUI using imagine-tui's MCP tools.
 
-### M3-1: goja sandbox setup
-- **TDD**: Write tests that scripts cannot access forbidden APIs
-- Initialize goja VM per-session (not per-script — `state` must persist)
-- Strip all I/O: no `require`, no `console.log` (provide `debug()` that writes to server log), no `fetch`, no `setTimeout`/`setInterval`
-- Confirm sandboxing: test that scripts attempting file/network access fail gracefully
-- **Tests**: forbidden API access, script error handling (syntax error, runtime error, infinite loop timeout)
+**Design doc**: [docs/demos/log-viewer.md](demos/log-viewer.md)
 
-### M3-2: $ API — current node
-- **TDD**: Write tests for every property read/write
-- Inject `$` as a proxy object bound to the current node
-- `$.value`, `$.props`, `$.style`, `$.children`, `$.visible`
-- Read operations return current DOM state. Write operations mutate the DOM and trigger re-render.
-- **Tests**: read each property, write each property, write triggers dirty flag, write to read-only prop fails
+#### M6-1: Demo project scaffold
+- Create `demo/log-viewer/` directory
+- `.mcp.json` with streamable HTTP URL config
+- Generate `sample-data/app.log` — realistic log data (~500 lines, mixed severities)
+- `README.md` with two-terminal setup instructions
 
-### M3-3: $ API — cross-node access
-- **TDD**: Write tests for $('id') access patterns
-- `$('id')` returns a proxy for any node in the DOM by ID
-- Same property surface as `$` (value, props, style, text, visible, rows)
-- Nonexistent ID returns a null-ish object that fails gracefully (no crash, returns undefined on reads)
-- **Tests**: access existing node, access nonexistent node, modify cross-node prop, chain access
+#### M6-2: System prompt (`demo/log-viewer/CLAUDE.md`)
+- Instructs Claude Code to build a log viewer using imagine-tui tools
+- Example `replace` payload for initial UI tree
+- Describes the `await_event` → `patch` interaction loop
+- Example goja scripts for local filtering
 
-### M3-4: emit()
-- **TDD**: Write tests for both local and claude emit paths
-- `emit('local', patchOps)` — apply patch ops to the DOM immediately, synchronously
-- `emit('claude', data)` — enqueue event in the event queue for `await_event`
-- `emit` with invalid target throws script error
-- **Tests**: local emit applies patch, local emit with invalid ops fails, claude emit enqueues, event queue integration
+#### M6-3: Smoke test — initial render
+- Start imagine-tui server, send `replace` with the log viewer tree via HTTP, call `query` to verify DOM state
+- Verifies: all node IDs exist, log widget populated, status bar computed prop works
 
-### M3-5: state object
-- **TDD**: Write tests for state persistence
-- `state` is a plain JS object that persists across script invocations within the same session
-- Scoped per-node: each node's scripts share one `state`, but different nodes have isolated state
-- `state` survives DOM patches (updating a node's scripts doesn't reset its state)
-- **Tests**: state persists across invocations, state isolation between nodes, state survives prop updates, state does not survive node removal
+#### M6-4: Smoke test — interaction loop
+- Simulate severity button click, verify filtered log entries
+- Simulate search input change, verify text filter applied
+- Verify status bar count updates
 
-### M3-6: Script lifecycle hooks
-- **TDD**: Write tests for each hook trigger condition
-- Wire hooks to DOM events: `on_mount` fires after insert, `on_change` fires after value mutation, `on_event` fires on child events (bubbling), `on_focus`/`on_blur`, `on_key`
-- Scripts execute synchronously (block the frame loop briefly — enforce a timeout, e.g., 10ms)
-- **Tests**: each hook fires at the right time, hook receives correct event payload, timeout kills runaway scripts
+#### M6-5: Manual end-to-end test
+- Full two-terminal demo flow
+- Iterate on system prompt until Claude Code reliably builds the UI
 
-### M3-7: Computed props
-- **TDD**: Write tests for dependency tracking and re-evaluation
-- Computed props are script strings that return a value
-- Runtime tracks which nodes a computed prop reads (via $('id') calls during evaluation)
-- When a dependency changes, re-evaluate the computed prop and update the node
-- Cycle detection: if A computes from B and B computes from A, error and break the cycle
-- **Tests**: basic computation, dependency tracking, re-evaluation on change, cycle detection, error in computed prop expression
+#### M6-6: Demo recording & polish
+- Record with asciinema or screen recording
+- README update with recording link
+- Performance check: measure latency of replace + await_event cycle
 
 ---
 
-## Milestone 4: Widget library (v1 core set) ✅
+### Milestone 7: Extended demos
 
-**Goal**: All v1 widget types render correctly to the terminal via Lip Gloss. Golden-file tests for every widget. TDD encouraged for behavior; golden files for visual output.
+**Goal**: Ship 2-3 more reference demos, exercising increasingly complex widget combinations and multi-tool orchestration.
 
-**Status**: Complete — 154 tests, all passing. Design doc at docs/widget/DESIGN.md.
+#### M7-1: Test whisperer demo
+Design doc: [docs/demos/test-whisperer.md](demos/test-whisperer.md)
+- Multi-tool orchestration (filesystem + shell), live row status updates
+- Exercises: table, code, log, button, text, container
 
-### M4-1: Widget registry & rendering pipeline ✅
-- Widget interface (Init/Update/View/Layout), Registry, Tree
-- Two-pass rendering pipeline (top-down layout, bottom-up render)
-- Theme with style token resolution
-- Type-safe prop helpers
-- **Tests**: registry, theme, prop helpers, render pipeline, focus propagation
-
-### M4-2: container widget ✅
-- Flex-like layout: `direction` (horizontal/vertical), `gap`, `padding`, `border`
-- Child width distribution: fixed (chars), percentage, `fill` (take remaining space)
-- **Tests**: 15 test cases covering all layout modes and edge cases
-
-### M4-3: text widget ✅
-- Styled text with token system, word wrap, max_lines, segments
-- **Tests**: 10 test cases
-
-### M4-4: input widget ✅
-- Single-line input with cursor, validation, submit/change events
-- **Tests**: 15 test cases
-
-### M4-5: textarea widget ✅
-- Multi-line editing with cursor row/col, newline insertion
-- **Tests**: 11 test cases
-
-### M4-6: select widget ✅
-- Single/multi-select, open/close, filter, arrow navigation
-- **Tests**: 12 test cases
-
-### M4-7: button widget ✅
-- Click on Enter/Space, disabled state, styled border
-- **Tests**: 7 test cases
-
-### M4-8: table widget ✅
-- Sortable columns, expandable rows, row styling via field→token map
-- **Tests**: 12 test cases
-
-### M4-9: list widget ✅
-- Vertical item list with badges, selection cursor, filter
-- **Tests**: 10 test cases
-
-### M4-10: diff widget ✅
-- Unified mode with line numbers, add/remove coloring, hunk navigation
-- Mode toggle, select_line event
-- **Tests**: 8 test cases
-
-### M4-11: log widget ✅
-- Severity coloring, timestamps, sticky-bottom, max_lines
-- **Tests**: 9 test cases
-
-### M4-12: code widget ✅
-- Line numbers, start_line offset, highlight_lines (ints and ranges)
-- **Tests**: 11 test cases
-
-### Deferred items
-See [docs/widget/DEFERRED.md](widget/DEFERRED.md) for deferred decisions and open questions.
-
----
-
-## Milestone 5: BubbleTea integration ✅
-
-**Goal**: The DOM renders live in a terminal via BubbleTea. The MCP server, DOM, scripts, and widgets are all wired together into a running application.
-
-**Status**: Complete — 43 tests, all passing. 88% coverage on render package.
-
-### M5-1: BubbleTea model & update loop ✅
-- Model struct: holds MCP Server, widget.Tree, FocusRing, dimensions, connection state
-- Update loop: routes KeyMsg, WindowSizeMsg, DOMChangedMsg, MCPDisconnectedMsg, ShutdownMsg
-- View: delegates to widget.Tree.Render() with focus awareness
-- **Tests**: 15 model tests (init, view, key routing, DOM change, disconnect, Ctrl+C quit)
-
-### M5-2: Focus management ✅
-- FocusRing: ordered list of focusable node IDs derived from DFS walk
-- Tab/Shift-Tab cycles focus with wrap-around
-- Container focus trapping via `focus_trap` prop on containers
-- `focusable` prop override on any node (opt-in or opt-out)
-- **Tests**: 15 focus tests (ring build, all types, prop override, next/prev, empty, contains, removal, trapping)
-
-### M5-3: MCP server ↔ BubbleTea bridge ✅
-- Bridge struct connects MCP Server to BubbleTea ProgramSender interface
-- DOMChangedMsg sent after MCP mutations; widget tree re-synced in Update()
-- Server.CallTool() for direct handler invocation (integration testing)
-- await_event blocks MCP goroutine, widget events enqueue to EventQueue
-- Event context auto-collects sibling values
-- **Tests**: 13 integration tests (replace/patch render, await_event block+return, timeout, concurrent ops, snapshot/restore, query, context collection, focus adjustment)
-
-### M5-4: Terminal resize handling ✅
-- WindowSizeMsg updates Model dimensions, triggers re-sync
-- Widget tree re-renders with new constraints
-- Zero-size viewport returns empty string
-- **Tests**: resize changes view, zero-size handling
-
-### M5-5: Startup & shutdown ✅
-- `imagine-tui serve` starts MCP on stdio + BubbleTea on stderr (alt screen)
-- Ctrl+C triggers graceful shutdown (server.Shutdown(), tea.Quit)
-- Broken pipe shows "MCP server disconnected" in TUI
-- Signal handling (SIGINT, SIGTERM)
-- **Tests**: Ctrl+C produces QuitMsg, disconnect shows message
-
----
-
-## Milestone 6: End-to-end demo — test whisperer
-
-**Goal**: The first reference demo runs end-to-end. This validates the full stack: MCP → DOM → scripts → widgets → terminal. It also serves as the integration test suite for the entire system.
-
-### M6-1: Demo script & system prompt
-- Write the Claude Code system prompt / CLAUDE.md instructions for the test whisperer demo
-- Define the MCP tool call sequence: initial `replace` with table + status bar, `await_event` loop
-- Write a mock test runner that produces canned failures for deterministic testing
-- Document the expected interaction flow
-
-### M6-2: Initial screen build
-- Claude Code calls `replace` with: header (text), failure table (table with row_style), status bar (text with computed summary)
-- Verify the full render pipeline: MCP → DOM → widgets → terminal
-- **Smoke test**: canned replace payload renders correctly
-
-### M6-3: Row interaction
-- User selects a row, presses Enter → event routed to Claude
-- Claude reads test file + source file (via filesystem MCP server)
-- Claude patches in a detail panel (code widget + text annotation + button)
-- **Smoke test**: canned event → canned patch → correct render
-
-### M6-4: Fix-it flow
-- User clicks "Fix it" → event to Claude
-- Claude writes file (via filesystem), runs test (via shell), patches row status
-- Row transitions from red to green with animation (style change)
-- **Smoke test**: full cycle with mock filesystem and shell
-
-### M6-5: Local scripts
-- Table sort/filter scripts (goja)
-- Computed summary: "3 of 14 fixed" updates automatically as rows change status
-- Status bar shows elapsed time (computed from `on_tick`)
-- **Tests**: sort script, filter script, computed summary accuracy
-
-### M6-6: Demo polish & recording
-- Record a terminal session (asciinema or similar) for the README
-- Write setup instructions: how to configure Claude Code MCP, run the server, trigger the demo
-- Performance profiling: measure latency at each tier
-
----
-
-## Milestone 7: Extended demos & hardening
-
-**Goal**: Ship 2-3 more reference demos, harden edge cases, prepare for external users.
-
-### M7-1: Living dashboard demo
-- Exercises multi-MCP-server orchestration, sparkline (may need v2 widget), container layout
+#### M7-2: Living dashboard demo
+Design doc: [docs/demos/living-dashboard.md](demos/living-dashboard.md)
+- Multi-MCP-server orchestration, sparkline (may need v2 widget), container layout
 - Requires sparkline widget implementation (promote from v2 if not already done)
 
-### M7-2: Log detective demo
-- Exercises log widget, cross-file reasoning, timeline visualization
+#### M7-3: Log detective demo
+Design doc: [docs/demos/log-detective.md](demos/log-detective.md)
 - Most complex multi-tool orchestration: log parsing + source file reading + causal tracing
+- Exercises: log, sparkline, text with annotations
 
-### M7-3: TSX fragment runtime
+---
+
+## Backlog (unscheduled)
+
+Items not tied to a milestone. Will be scheduled as needed.
+
+### TSX fragment runtime
 - Implement the JSX transform in the goja layer
 - Component registry: `<ListItem>`, `<Text>`, `<Container>` → DOM node specs
 - Compile step: string transform before passing to goja, or runtime tagged template processing
 - **TDD**: transform input/output pairs, component registry lookup, fragment rendering
 
-### M7-4: Session persistence
+### Session persistence
 - Serialize DOM + snapshot store + script state to JSON on disk
 - Resume from serialized state on startup
 - **TDD**: serialize/deserialize round-trip, resume renders correctly
 
-### M7-5: Error recovery & resilience
+### Error recovery & resilience
 - Script timeout handling (goja interrupt)
 - Malformed patch recovery (error message shown in TUI, not crash)
 - MCP reconnection after disconnect
 - DOM consistency checks (orphaned nodes, dangling references)
 - **TDD**: every error path, every recovery mechanism
 
-### M7-6: Documentation & packaging
+### Documentation & packaging
 - README with architecture overview, quickstart, demo walkthroughs
 - MCP tool schema documentation (auto-generated from Go types)
 - Go binary releases for macOS (arm64, amd64), Linux (amd64)
@@ -409,14 +166,14 @@ See [docs/widget/DEFERRED.md](widget/DEFERRED.md) for deferred decisions and ope
 ## Milestone ordering & dependencies
 
 ```
-M0 (skeleton)
- └→ M1 (DOM)           ← foundation, must be rock-solid
-     ├→ M2 (MCP)       ← protocol layer atop DOM
-     └→ M3 (scripts)   ← scripting atop DOM
-         └→ M4 (widgets) ← rendering atop DOM + scripts
-              └→ M5 (BubbleTea integration) ← wires everything together
-                   └→ M6 (test whisperer demo) ← first end-to-end
-                        └→ M7 (extended demos & hardening)
+M0 (skeleton) ✅
+ └→ M1 (DOM) ✅
+     ├→ M2 (MCP) ✅
+     └→ M3 (scripts) ✅
+         └→ M4 (widgets) ✅
+              └→ M5 (BubbleTea integration) ✅
+                   └→ M6 (log viewer demo)
+                        └→ M7 (extended demos)
 ```
 
 M1 is the critical path. M2 and M3 can proceed in parallel once M1 is complete. M4 depends on M3 (widgets need to trigger scripts). M5 depends on M2 + M4 (wires MCP and widgets into BubbleTea). M6 is the integration proof. M7 is iterative.
@@ -425,13 +182,11 @@ M1 is the critical path. M2 and M3 can proceed in parallel once M1 is complete. 
 
 | Milestone | Tickets | Estimated effort | Risk |
 |-----------|---------|-----------------|------|
-| M0: Skeleton | 3 | 1–2 days | Low |
-| M1: DOM | 7 | 2–3 weeks | Medium (design decisions in patch semantics) |
-| M2: MCP | 7 | 1–2 weeks | Low (protocol is well-defined) |
-| M3: Scripts | 7 | 2–3 weeks | High (goja edge cases, sandboxing) |
-| M4: Widgets | 12 | 3–4 weeks | Medium (visual polish is iterative) |
-| M5: Integration | 5 | 2–3 weeks | High (concurrency, BubbleTea bridge) |
-| M6: Test whisperer | 6 | 1–2 weeks | Medium (first e2e, expect surprises) |
-| M7: Extended | 6 | 3–4 weeks | Medium |
-
-**Total: ~16–22 weeks for one developer, ~10–14 weeks for two working in parallel on M2/M3 after M1.**
+| M0: Skeleton ✅ | 3 | 1–2 days | Low |
+| M1: DOM ✅ | 7 | 2–3 weeks | Medium |
+| M2: MCP ✅ | 7 | 1–2 weeks | Low |
+| M3: Scripts ✅ | 7 | 2–3 weeks | High |
+| M4: Widgets ✅ | 12 | 3–4 weeks | Medium |
+| M5: Integration ✅ | 5 | 2–3 weeks | High (concurrency, BubbleTea bridge) |
+| M6: Log viewer | 6 | 1–2 weeks | Medium (first e2e, expect surprises) |
+| M7: Extended demos | 3 | 2–3 weeks | Medium |

--- a/docs/demos/living-dashboard.md
+++ b/docs/demos/living-dashboard.md
@@ -1,0 +1,46 @@
+# Living Dashboard Demo
+
+## Goal
+
+Claude reads project metadata (package.json, git log, GitHub issues, CI status, TODO comments) and builds a multi-panel dashboard with sparklines, tables, and gauges. Click any metric for Claude's explanation. Validates multi-MCP-server orchestration and complex container layout.
+
+## Widgets exercised
+
+- **container** — multi-panel grid layout (the core challenge)
+- **table** — issues list, CI results, dependency versions
+- **text** — metric labels, Claude explanations
+- **sparkline** — may need v2 widget promotion; trend lines for commit frequency, issue velocity, build times
+
+## External tools required
+
+- **Filesystem MCP** — read package.json, scan for TODO comments
+- **Git MCP** — git log, branch status, contributor stats
+- **GitHub MCP** — issues, PRs, CI status
+
+This is the most demanding demo for **multi-MCP-server orchestration**: Claude must call 3+ MCP servers, aggregate the data, and build a coherent dashboard.
+
+## MCP tool sequence
+
+1. Claude reads project metadata via filesystem, git, and GitHub MCP servers
+2. `replace` — build multi-panel dashboard layout
+3. `await_event` — wait for user to click a metric
+4. User clicks a metric → event to Claude
+5. Claude fetches additional detail (e.g., recent commits for a sparkline spike)
+6. `patch` — insert explanation panel
+7. Back to `await_event`
+
+## Local scripts (goja)
+
+- **Auto-refresh**: periodic data re-fetch via `on_tick` (if supported)
+- **Panel collapse/expand**: local script toggles panel visibility
+
+## Key challenges
+
+- Sparkline widget may not exist in v1 core set — needs promotion from v2 or placeholder
+- Container layout must handle 4-6 panels in a responsive grid
+- Data aggregation from multiple MCP servers requires careful prompt engineering
+
+## Smoke tests
+
+- Scripted test: send canned dashboard `replace` payload, verify all panels render
+- Scripted test: click a metric, verify explanation panel appears

--- a/docs/demos/log-detective.md
+++ b/docs/demos/log-detective.md
@@ -1,0 +1,47 @@
+# Log Detective Demo
+
+## Goal
+
+Pipe logs in, Claude structures them: timeline, severity heatmap, anomaly panel with causal tracing. Click a spike to scroll to that moment. This is the most complex multi-tool orchestration demo, combining log parsing, source file reading, and causal reasoning.
+
+## Widgets exercised
+
+- **log** — main log display with severity coloring, timestamps, ANSI passthrough
+- **text** — annotations with inline highlights, causal trace explanations
+- **sparkline** — severity heatmap / timeline visualization (may need v2 widget)
+- **container** — split layout: timeline + log + detail panel
+
+## External tools required
+
+- **Filesystem MCP** — read source files for causal tracing
+- **Shell MCP** — potentially pipe live logs
+
+## MCP tool sequence
+
+1. Claude reads log file(s) via filesystem
+2. `replace` — build layout: timeline (sparkline), log view, anomaly panel
+3. Claude analyzes log patterns, identifies anomalies
+4. `patch` — annotate anomalies in the log, populate timeline
+5. `await_event` — wait for user interaction
+6. User clicks a spike on the timeline → event to Claude
+7. Claude scrolls log to that moment, reads source files for context
+8. `patch` — insert causal trace panel with source context
+9. Back to `await_event`
+
+## Local scripts (goja)
+
+- **Severity filtering**: toggle severity levels locally
+- **Timeline scrubbing**: scroll log to match timeline position
+- **Anomaly highlighting**: highlight log entries that match anomaly patterns
+
+## Key challenges
+
+- Cross-file source reasoning: Claude must connect log entries to source code locations
+- Timeline visualization: may need sparkline or a custom timeline widget
+- Log volume: must handle 1000+ lines efficiently (log widget's `max_lines` and `sticky_bottom`)
+- Most complex multi-tool orchestration of all demos
+
+## Smoke tests
+
+- Scripted test: send canned log data via `replace`, verify log widget renders
+- Scripted test: click timeline spike, verify log scrolls and detail panel appears

--- a/docs/demos/log-viewer.md
+++ b/docs/demos/log-viewer.md
@@ -1,0 +1,171 @@
+# Log Viewer Demo (Milestone 6)
+
+The first end-to-end demo of imagine-tui. Validates the full stack: MCP → DOM → scripts → widgets → terminal.
+
+## Goal
+
+User opens a separate Claude Code session, prompts "build me a log viewer for the sample data," and Claude Code constructs a live TUI using imagine-tui's MCP tools. The log viewer displays log entries with severity filtering, text search, and Claude-powered error explanation.
+
+## Isolation architecture
+
+Unix domain socket transport separates the TUI terminal from the Claude Code session. The MCP Go SDK v1.4.0 provides `IOTransport{Reader, Writer}` which wraps any `io.ReadWriteCloser`, and `Server.Connect()` for per-connection sessions.
+
+```
+Terminal A                          Terminal B
+┌──────────────────────┐           ┌──────────────────────┐
+│ imagine-tui serve    │           │ claude               │
+│   --socket *.sock    │◄──Unix──► │   (demo session)     │
+│                      │  socket   │                      │
+│ BubbleTea renders    │           │ Reads CLAUDE.md,     │
+│ the TUI on stdout    │           │ calls MCP tools,     │
+│                      │           │ builds the log viewer│
+└──────────────────────┘           └──────────────────────┘
+```
+
+- **Terminal A**: `imagine-tui serve --socket /tmp/imagine-tui.sock` — owns the terminal for BubbleTea rendering, listens on a Unix socket for MCP
+- **Terminal B**: `cd demo/log-viewer && claude` — separate Claude Code session with project-scoped `.mcp.json`
+- **Zero interference** with development sessions — Claude Code spawns `imagine-tui connect <path>` as a stdio subprocess that bridges to the socket
+
+### Why Unix domain sockets?
+
+- No port allocation or HTTP overhead — same-host IPC only
+- Clean separation: BubbleTea owns Terminal A's stdout, MCP uses a Unix socket
+- No `/dev/tty` conflicts (two TUI apps can't share a terminal)
+- No tmux/screen dependency
+- Claude Code supports stdio MCP servers via `"command"`/`"args"` in `.mcp.json`; the `connect` subcommand bridges stdio ↔ socket transparently
+
+## Widgets exercised
+
+- **container** — nested flex layout (vertical root + horizontal main)
+- **text** — header, severity filter label, status bar with computed props
+- **log** — main log display with severity coloring, timestamps, sticky-bottom auto-scroll
+- **button** — severity filter toggles (DEBUG, INFO, WARN, ERROR)
+- **input** — text search/filter
+
+## UI structure
+
+Built by Claude Code via a single `replace` call:
+
+```
+container (id: "root", direction: vertical)
+├── text (id: "header", content: "Log Viewer — app.log")
+├── container (id: "main", direction: horizontal)
+│   ├── container (id: "sidebar", width: 25%)
+│   │   ├── text (id: "filter-label", content: "Severity Filter")
+│   │   ├── button (id: "sev-debug", label: "DEBUG")
+│   │   ├── button (id: "sev-info",  label: "INFO")
+│   │   ├── button (id: "sev-warn",  label: "WARN")
+│   │   ├── button (id: "sev-error", label: "ERROR")
+│   │   └── input (id: "search", placeholder: "Search...")
+│   └── log (id: "log-view", width: fill, sticky_bottom: true)
+└── text (id: "status-bar", computed: { "content": "state.filtered + ' of ' + state.total + ' entries'" })
+```
+
+## Interaction flow
+
+### Initial setup
+1. Claude reads `sample-data/app.log` via built-in filesystem access
+2. Claude calls `replace` with the full UI tree (above)
+3. Log widget is populated with parsed log entries
+4. Claude calls `await_event` — blocks until user interaction
+
+### Local interactions (instant, via goja scripts)
+5. **Severity button click** → `on_event` script toggles that severity level on/off, filters log entries, patches log widget via `emit('local', patchOps)`. Status bar updates via computed prop.
+6. **Search input change** → `on_change` script filters entries matching the search term, updates log widget locally.
+
+### Claude-routed interactions (1-3s round trip)
+7. **Select a log entry** (if supported) → `emit('claude', { line, severity, message })` → Claude explains the error, reads source files for context
+8. Claude calls `patch` to insert an explanation panel below the log
+9. Back to `await_event`
+
+## Local scripts (goja)
+
+### Severity filter (`on_event` on each severity button)
+```javascript
+// Toggles severity, filters entries, updates log widget
+var sev = $.props.label;
+state.filters = state.filters || { DEBUG: true, INFO: true, WARN: true, ERROR: true };
+state.filters[sev] = !state.filters[sev];
+
+var allEntries = state.allEntries || [];
+var filtered = allEntries.filter(function(e) { return state.filters[e.severity]; });
+state.filtered = filtered.length;
+
+emit('local', [{ op: 'update', id: 'log-view', props: { lines: filtered } }]);
+```
+
+### Text search (`on_change` on search input)
+```javascript
+var term = $.value.toLowerCase();
+var allEntries = state.allEntries || [];
+var filtered = allEntries.filter(function(e) {
+  return e.message.toLowerCase().indexOf(term) !== -1;
+});
+state.filtered = filtered.length;
+
+emit('local', [{ op: 'update', id: 'log-view', props: { lines: filtered } }]);
+```
+
+### Computed status bar
+```javascript
+state.filtered + ' of ' + state.total + ' entries'
+```
+
+## External tools required
+
+- **Filesystem** — built into Claude Code, used to read `sample-data/app.log`
+- No shell, git, or other MCP servers needed — this is the simplest possible demo
+
+## Demo project structure
+
+```
+demo/log-viewer/
+  CLAUDE.md             # System prompt for the demo Claude Code session
+  .mcp.json             # MCP server config: { "mcpServers": { "imagine-tui": { "command": "imagine-tui", "args": ["connect", "/tmp/imagine-tui.sock"] } } }
+  sample-data/
+    app.log             # ~500 lines, mixed severities, realistic timestamps and messages
+  README.md             # How to run the demo (two-terminal setup)
+```
+
+## Sample data format
+
+`sample-data/app.log` should contain ~500 lines of realistic application logs:
+
+```
+2026-03-13T10:00:01.234Z INFO  [server] Starting HTTP server on :8080
+2026-03-13T10:00:01.456Z DEBUG [db] Connection pool initialized (max=10)
+2026-03-13T10:00:02.789Z INFO  [auth] OAuth2 provider configured
+2026-03-13T10:00:05.123Z WARN  [cache] Redis connection timeout, retrying...
+2026-03-13T10:00:05.456Z ERROR [cache] Redis connection failed after 3 retries
+2026-03-13T10:00:06.789Z INFO  [server] Health check endpoint ready
+...
+```
+
+Requirements:
+- Timestamps in ISO 8601 format
+- Severity levels: DEBUG, INFO, WARN, ERROR (roughly 40% INFO, 30% DEBUG, 20% WARN, 10% ERROR)
+- Component tags in brackets: `[server]`, `[db]`, `[auth]`, `[cache]`, `[api]`, `[worker]`
+- Realistic messages including stack traces for ERROR entries
+- Some multi-line entries (stack traces, JSON payloads)
+
+## Smoke tests
+
+### Initial render test
+Start imagine-tui server, connect via Unix socket, send `replace` with the log viewer tree, call `query`:
+- All node IDs exist in the DOM
+- Log widget has entries
+- Status bar computed prop evaluates correctly
+
+### Interaction test
+- Simulate severity button click → verify log entries filtered
+- Simulate search input change → verify text filter applied
+- Verify status bar count updates
+
+## How to run
+
+1. Build imagine-tui: `go build -o imagine-tui ./cmd/imagine-tui` and ensure it's on `$PATH`
+2. Start the server: `./imagine-tui serve --socket /tmp/imagine-tui.sock` (Terminal A)
+3. Open a new terminal, navigate to the demo: `cd demo/log-viewer` (Terminal B)
+4. Start Claude Code: `claude` (Terminal B)
+5. Prompt: "Build me a log viewer for the sample data in sample-data/app.log"
+6. Watch the TUI appear in Terminal A

--- a/docs/demos/test-whisperer.md
+++ b/docs/demos/test-whisperer.md
@@ -1,0 +1,87 @@
+# Test Whisperer Demo
+
+## Goal
+
+Run tests, show failures with Claude-diagnosed summaries, click to see source + fix, click "Fix it" to write the patch and re-run. This is the most complex single-session demo, exercising multi-tool orchestration and live status updates.
+
+## Widgets exercised
+
+- **table** — failure list with sortable columns, expandable row detail, row-level status styling (red → green on fix)
+- **code** — source context with line-range highlighting
+- **log** — test output display
+- **text** — header, status bar with computed summary
+- **button** — "Fix it" action trigger
+- **container** — overall layout
+
+## External tools required
+
+- **Filesystem MCP** — read test files and source files
+- **Shell MCP** — run tests, apply patches
+
+## MCP tool sequence
+
+1. `replace` — initial screen: header (text), failure table (table with `row_style`), status bar (text with computed summary)
+2. `await_event` — wait for user to select a row
+3. User selects a row, presses Enter → event routed to Claude
+4. Claude reads test file + source file (via filesystem MCP server)
+5. `patch` — insert detail panel: code widget (showing source), text annotation, button ("Fix it")
+6. `await_event` — wait for "Fix it" click
+7. User clicks "Fix it" → event to Claude
+8. Claude writes file (via filesystem), runs test (via shell)
+9. `patch` — update row status from red to green
+10. Back to step 2
+
+## Local scripts (goja)
+
+- **Table sort/filter**: sort by file name, test name, or severity
+- **Computed summary**: `"3 of 14 fixed"` — updates automatically as rows change status via computed prop
+- **Status bar elapsed time**: computed from `on_tick` hook
+
+## Mock test runner
+
+For deterministic testing, a mock test runner produces canned failures:
+- Fixed set of ~14 test failures across 3-4 files
+- Each failure has: test name, file path, line number, error message, expected vs actual
+- Running a "fixed" test returns success
+
+## Tickets (preserved from original M6 design)
+
+### Demo script & system prompt
+- Write the Claude Code system prompt / CLAUDE.md instructions for the test whisperer demo
+- Define the MCP tool call sequence: initial `replace` with table + status bar, `await_event` loop
+- Write a mock test runner that produces canned failures for deterministic testing
+- Document the expected interaction flow
+
+### Initial screen build
+- Claude Code calls `replace` with: header (text), failure table (table with row_style), status bar (text with computed summary)
+- Verify the full render pipeline: MCP → DOM → widgets → terminal
+- **Smoke test**: canned replace payload renders correctly
+
+### Row interaction
+- User selects a row, presses Enter → event routed to Claude
+- Claude reads test file + source file (via filesystem MCP server)
+- Claude patches in a detail panel (code widget + text annotation + button)
+- **Smoke test**: canned event → canned patch → correct render
+
+### Fix-it flow
+- User clicks "Fix it" → event to Claude
+- Claude writes file (via filesystem), runs test (via shell), patches row status
+- Row transitions from red to green with animation (style change)
+- **Smoke test**: full cycle with mock filesystem and shell
+
+### Local scripts
+- Table sort/filter scripts (goja)
+- Computed summary: "3 of 14 fixed" updates automatically as rows change status
+- Status bar shows elapsed time (computed from `on_tick`)
+- **Tests**: sort script, filter script, computed summary accuracy
+
+### Demo polish & recording
+- Record a terminal session (asciinema or similar) for the README
+- Write setup instructions: how to configure Claude Code MCP, run the server, trigger the demo
+- Performance profiling: measure latency at each tier
+
+## Smoke tests
+
+- Scripted test: start server, send canned `replace` payload, verify DOM via `query`
+- Scripted test: send canned event, send canned `patch`, verify render output
+- Scripted test: full fix-it cycle with mock filesystem and shell

--- a/docs/feedback-session-2025-03-13T133201.md
+++ b/docs/feedback-session-2025-03-13T133201.md
@@ -1,0 +1,45 @@
+# Feedback: Spaceship Launch Demo Analysis — 2025-03-13
+
+## Context
+
+Claude Code was given the imagine-tui MCP tools and told to "surprise me with a demo." It autonomously built a spaceship launch dashboard with countdown timer, status panels, and scrolling event log. This analysis identifies gaps and enhancements based on what that demo pattern would exercise against the current widget system.
+
+## Learnings
+
+### 1. Missing widget: progress bar / gauge
+
+A launch countdown naturally wants progress indicators — fuel levels, system readiness %, countdown progress. Right now the LLM has to fake this with text widgets and Unicode block characters like `▓▓▓▓░░░░ 40%`. A `progress` widget would be trivial to implement and very high-leverage for dashboards.
+
+**Recommendation**: Implement a `progress` widget. Props: `value` (0-100), `label`, `style`, `show_percent` (bool). Small implementation, big impact.
+
+### 2. No auto-refresh / timer mechanism
+
+A countdown timer requires periodic updates. The only way to do this today is the LLM calling `patch` in a loop (burning tokens each cycle) or abusing `await_event` with `timeout_ms` as a poor man's timer. Options:
+
+- A server-side `set_timer` tool that fires tick events the LLM can ignore
+- A goja `on_tick` script hook (already mentioned in the living-dashboard design doc)
+
+**Recommendation**: Backlog for now. The `await_event` timeout loop works, and the goja script layer (M3) already supports lifecycle hooks that could be extended.
+
+### 3. Text alignment prop
+
+Status panels showing `System: NOMINAL` with values right-aligned need careful manual padding. The `text` widget could support an `align` prop (`"left"`, `"center"`, `"right"`).
+
+**Recommendation**: Small enhancement, add to text widget.
+
+### 4. The "status table" is THE killer pattern
+
+A table of `{system: "Engines", status: "NOMINAL", value: "100%"}` with `row_style` mapping status to colors is exactly what the table widget + `set_items` was built for. The spaceship demo validates this pattern works well. The `row_style` conditional styling feature is powerful here.
+
+### 5. Append-only log + status panels = the canonical dashboard
+
+The spaceship demo is essentially: header + horizontal container (status table | log widget). This pattern should be our template for dashboard-style demos going forward.
+
+## Priority
+
+| Enhancement | Effort | Impact | Priority |
+|-------------|--------|--------|----------|
+| Progress bar widget | Small (1 file + tests) | High — fills biggest gap for dashboards | **P1** |
+| Text align prop | Tiny | Medium — convenience for status panels | P2 |
+| Timer / auto-refresh | Medium | Medium — saves tokens but await_event works | Backlog |
+| Sparkline widget | Medium | Medium — needed for living-dashboard demo (M7) | M7 |

--- a/docs/feedback-session-2026-03-13T173112Z.md
+++ b/docs/feedback-session-2026-03-13T173112Z.md
@@ -1,0 +1,76 @@
+# MCP Feedback Session — 2026-03-13
+
+Feedback from Claude (Opus 4.6) after building an interactive "Space Launch Mission Control" demo using the imagine-tui MCP server. The demo used: container, text, table, log, and button widgets with live updates via `patch` and `set_items`.
+
+---
+
+## 1. The Log Widget Was the Biggest Pain Point
+
+Attempted `append_items` on the log widget and got:
+
+```
+append_items: node "mission-log": missing item_template prop
+```
+
+This forced **resending the entire `lines` array via `patch` on every update**. For the countdown sequence, that meant shipping all previous log lines plus the new one each time — massively token-wasteful. By the end, 15+ lines were being sent just to add one.
+
+**Suggestion:** The log widget should natively support `append_items` (or a dedicated `append_lines` tool). It's an append-only widget by nature. This would be the single biggest improvement for token efficiency.
+
+---
+
+## 2. Scripting Was NOT Exposed via MCP
+
+The scripting system is **not discoverable through the MCP tools**:
+
+- `describe_widgets` doesn't mention `scripts`, `computed`, `on_change`, `on_mount`, or any hook props on any widget
+- There's no `describe_scripting` or similar discovery tool
+- A fresh Claude session with no codebase access would have **zero awareness** that scripting exists
+
+This matters because:
+
+- **Computed props** could have replaced several `patch` calls (e.g., the header status text could react to a state change instead of being manually updated)
+- **`on_change` / `on_mount` hooks** could have driven the systems-check cascade locally without round-tripping to Claude
+- **`emit('local', patch)`** could have handled the countdown animation entirely client-side
+
+**Suggestion:** Either add scripting props to the `describe_widgets` output, or add a `describe_scripting` tool that explains the `$` API, hooks, computed props, emit, and state.
+
+---
+
+## 3. No Way to Do Timed Sequences Without Round-Trips
+
+The countdown required ~10 sequential `patch` calls, each a full MCP round-trip. There was no timer primitive available. The spec mentions `on_tick` as a hook — if that exists, exposing it via scripting would allow:
+
+```json
+{
+  "on_tick": "if (state.count > 0) { state.count--; $('countdown').text = 'T-' + state.count; }"
+}
+```
+
+That would turn 10 MCP calls into 1.
+
+---
+
+## 4. Smaller Feedback
+
+| Issue | Detail |
+|-------|--------|
+| **`set_items` vs `patch` confusion** | For the table, `set_items` worked great. For the log, it didn't. The mental model of "which update mechanism works on which widget" wasn't clear from `describe_widgets`. |
+| **No partial log update** | Even a `patch` op like `{"op": "append_prop", "id": "mission-log", "prop": "lines", "values": [...]}` would help. |
+| **`row_style` is great** | The conditional row styling on the table was zero effort, big visual payoff. |
+| **Widget catalog was helpful** | `describe_widgets` returning everything in one call was the right move. Planning the whole layout from a single response worked well. |
+| **`dom_summary` in events is clever** | Returning the tree shape with each event gives just enough context without flooding tokens. |
+
+---
+
+## Priority List
+
+1. **Log `append_items` support** — biggest token waste by far
+2. **Expose scripting in `describe_widgets` / new discovery tool** — invisible to MCP clients
+3. **Timer/tick primitive** — enables animations without round-trips
+4. **Partial prop append** — for any array-valued prop, not just items
+
+---
+
+## What Worked Well
+
+The widget set, `set_items` pattern, conditional `row_style`, and event model all felt natural. The `dom_summary` in event responses is a smart design. The main gap is that the powerful scripting layer is invisible to MCP clients.

--- a/internal/dom/patch.go
+++ b/internal/dom/patch.go
@@ -14,6 +14,7 @@ const (
 	OpInsert OpType = "insert"
 	OpRemove OpType = "remove"
 	OpMove   OpType = "move"
+	OpAppend OpType = "append"
 )
 
 // PatchOp represents a single patch operation.
@@ -25,8 +26,10 @@ type PatchOp struct {
 	Props    map[string]any    `json:"props,omitempty"`     // for update and insert
 	Scripts  map[string]string `json:"scripts,omitempty"`
 	Computed map[string]string `json:"computed,omitempty"`
-	NodeType NodeType          `json:"type,omitempty"` // for insert
-	Node     *NodeSpec         `json:"node,omitempty"` // full node spec for insert (alternative to flat fields)
+	NodeType NodeType          `json:"type,omitempty"`   // for insert
+	Node     *NodeSpec         `json:"node,omitempty"`   // full node spec for insert (alternative to flat fields)
+	Prop     string            `json:"prop,omitempty"`   // for append: which prop to append to
+	Values   []any             `json:"values,omitempty"` // for append: values to append
 }
 
 // NodeSpec is a JSON-friendly node specification for insert operations.
@@ -71,6 +74,8 @@ func (t *Tree) Patch(ops []PatchOp) error {
 			err = t.applyRemove(op)
 		case OpMove:
 			err = t.applyMove(op)
+		case OpAppend:
+			err = t.applyAppend(op)
 		default:
 			err = fmt.Errorf("unknown op type %q", op.Op)
 		}
@@ -162,6 +167,34 @@ func (t *Tree) applyMove(op PatchOp) error {
 		return fmt.Errorf("move node %q: parent_id is required", op.ID)
 	}
 	return t.Move(op.ID, op.ParentID, op.AfterID)
+}
+
+func (t *Tree) applyAppend(op PatchOp) error {
+	if op.ID == "" {
+		return fmt.Errorf("append: node ID is required")
+	}
+	if op.Prop == "" {
+		return fmt.Errorf("append node %q: prop name is required", op.ID)
+	}
+	node := t.Find(op.ID)
+	if node == nil {
+		return fmt.Errorf("append: node %q not found", op.ID)
+	}
+	if len(op.Values) == 0 {
+		return nil
+	}
+	existing, ok := node.GetProp(op.Prop)
+	if !ok {
+		// Create new array prop.
+		node.SetProp(op.Prop, op.Values)
+		return nil
+	}
+	arr, ok := existing.([]any)
+	if !ok {
+		return fmt.Errorf("append node %q: prop %q is not an array", op.ID, op.Prop)
+	}
+	node.SetProp(op.Prop, append(arr, op.Values...))
+	return nil
 }
 
 // snapshot creates a deep copy of the tree for rollback.

--- a/internal/dom/patch_test.go
+++ b/internal/dom/patch_test.go
@@ -639,3 +639,169 @@ func TestPatchOpJSON(t *testing.T) {
 		t.Error("round-trip mismatch")
 	}
 }
+
+// --- Append patch op tests ---
+
+func TestPatchAppend_ToExistingArray(t *testing.T) {
+	tree := makeTestTree(t)
+	tree.Find("a1").SetProp("tags", []any{"x", "y"})
+
+	err := tree.Patch([]PatchOp{
+		{Op: OpAppend, ID: "a1", Prop: "tags", Values: []any{"z", "w"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	v, _ := tree.Find("a1").GetProp("tags")
+	arr := v.([]any)
+	if len(arr) != 4 {
+		t.Fatalf("got %d items, want 4", len(arr))
+	}
+	if arr[2] != "z" || arr[3] != "w" {
+		t.Error("appended values incorrect")
+	}
+}
+
+func TestPatchAppend_ToEmptyArray(t *testing.T) {
+	tree := makeTestTree(t)
+	tree.Find("a1").SetProp("tags", []any{})
+
+	err := tree.Patch([]PatchOp{
+		{Op: OpAppend, ID: "a1", Prop: "tags", Values: []any{"a"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	v, _ := tree.Find("a1").GetProp("tags")
+	arr := v.([]any)
+	if len(arr) != 1 || arr[0] != "a" {
+		t.Errorf("got %v, want [a]", arr)
+	}
+}
+
+func TestPatchAppend_CreatesNewProp(t *testing.T) {
+	tree := makeTestTree(t)
+	// "tags" prop does not exist on a1
+
+	err := tree.Patch([]PatchOp{
+		{Op: OpAppend, ID: "a1", Prop: "tags", Values: []any{"new"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	v, ok := tree.Find("a1").GetProp("tags")
+	if !ok {
+		t.Fatal("tags prop not created")
+	}
+	arr := v.([]any)
+	if len(arr) != 1 || arr[0] != "new" {
+		t.Errorf("got %v, want [new]", arr)
+	}
+}
+
+func TestPatchAppend_ToNonArrayFails(t *testing.T) {
+	tree := makeTestTree(t)
+	tree.Find("a1").SetProp("text", "hello")
+
+	err := tree.Patch([]PatchOp{
+		{Op: OpAppend, ID: "a1", Prop: "text", Values: []any{"world"}},
+	})
+	if err == nil {
+		t.Fatal("expected error for non-array prop")
+	}
+	// Verify rollback: text should still be "hello"
+	v, _ := tree.Find("a1").GetProp("text")
+	if v != "hello" {
+		t.Errorf("text = %v after rollback, want hello", v)
+	}
+}
+
+func TestPatchAppend_EmptyValues(t *testing.T) {
+	tree := makeTestTree(t)
+	tree.Find("a1").SetProp("tags", []any{"x"})
+
+	err := tree.Patch([]PatchOp{
+		{Op: OpAppend, ID: "a1", Prop: "tags", Values: nil},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	v, _ := tree.Find("a1").GetProp("tags")
+	arr := v.([]any)
+	if len(arr) != 1 {
+		t.Errorf("got %d items, want 1 (no-op)", len(arr))
+	}
+}
+
+func TestPatchAppend_MissingNodeFails(t *testing.T) {
+	tree := makeTestTree(t)
+	err := tree.Patch([]PatchOp{
+		{Op: OpAppend, ID: "nonexistent", Prop: "tags", Values: []any{"x"}},
+	})
+	if err == nil {
+		t.Fatal("expected error for missing node")
+	}
+}
+
+func TestPatchAppend_MissingID(t *testing.T) {
+	tree := makeTestTree(t)
+	err := tree.Patch([]PatchOp{
+		{Op: OpAppend, ID: "", Prop: "tags", Values: []any{"x"}},
+	})
+	if err == nil {
+		t.Fatal("expected error for empty ID")
+	}
+}
+
+func TestPatchAppend_MissingProp(t *testing.T) {
+	tree := makeTestTree(t)
+	err := tree.Patch([]PatchOp{
+		{Op: OpAppend, ID: "a1", Prop: "", Values: []any{"x"}},
+	})
+	if err == nil {
+		t.Fatal("expected error for empty prop name")
+	}
+}
+
+func TestPatchAppend_InMultiOp(t *testing.T) {
+	tree := makeTestTree(t)
+	tree.Find("a1").SetProp("tags", []any{"x"})
+
+	// First op succeeds (append), second fails (update nonexistent) — rollback.
+	err := tree.Patch([]PatchOp{
+		{Op: OpAppend, ID: "a1", Prop: "tags", Values: []any{"y"}},
+		{Op: OpUpdate, ID: "nonexistent", Props: map[string]any{"text": "x"}},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	// tags should be rolled back to ["x"].
+	v, _ := tree.Find("a1").GetProp("tags")
+	arr := v.([]any)
+	if len(arr) != 1 || arr[0] != "x" {
+		t.Errorf("tags = %v after rollback, want [x]", arr)
+	}
+}
+
+func TestParsePatchOps_WithAppend(t *testing.T) {
+	raw := `[{"op":"append","id":"log","prop":"lines","values":[{"text":"hello","level":"info"}]}]`
+	ops, err := ParsePatchOps([]byte(raw))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ops) != 1 {
+		t.Fatalf("expected 1 op, got %d", len(ops))
+	}
+	if ops[0].Op != OpAppend {
+		t.Errorf("op = %q, want append", ops[0].Op)
+	}
+	if ops[0].ID != "log" {
+		t.Errorf("id = %q, want log", ops[0].ID)
+	}
+	if ops[0].Prop != "lines" {
+		t.Errorf("prop = %q, want lines", ops[0].Prop)
+	}
+	if len(ops[0].Values) != 1 {
+		t.Fatalf("expected 1 value, got %d", len(ops[0].Values))
+	}
+}

--- a/internal/dom/template.go
+++ b/internal/dom/template.go
@@ -1,0 +1,150 @@
+package dom
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// ExpandTemplate expands a template NodeSpec for each item in the data slice.
+// parentID is used as a prefix for generated IDs.
+// Each item is a map[string]any. If an item has a "key" field (string), it is
+// used in the generated ID: "{parentID}-{key}". Otherwise, the 0-based index
+// is used: "{parentID}-{index}".
+func ExpandTemplate(parentID string, tmpl *NodeSpec, items []map[string]any) ([]*NodeSpec, error) {
+	return ExpandTemplateAt(parentID, tmpl, items, 0)
+}
+
+// ExpandTemplateAt is like ExpandTemplate but starts index-based IDs at offset.
+// This is used by AppendItems to avoid ID collisions with existing children.
+func ExpandTemplateAt(parentID string, tmpl *NodeSpec, items []map[string]any, offset int) ([]*NodeSpec, error) {
+	if tmpl == nil {
+		return nil, fmt.Errorf("expand template: template is nil")
+	}
+	if len(items) == 0 {
+		return nil, nil
+	}
+
+	specs := make([]*NodeSpec, 0, len(items))
+	for i, item := range items {
+		suffix := itemSuffix(item, i+offset)
+		idPrefix := parentID + "-" + suffix
+		spec := expandSpec(idPrefix, tmpl, item, 0)
+		specs = append(specs, spec)
+	}
+	return specs, nil
+}
+
+// ParseItemTemplate extracts and validates the item_template prop from a Node.
+// Returns the template as a *NodeSpec, or an error if the prop is missing or malformed.
+func ParseItemTemplate(node *Node) (*NodeSpec, error) {
+	raw, ok := node.Props["item_template"]
+	if !ok {
+		return nil, fmt.Errorf("node %q: missing item_template prop", node.ID)
+	}
+	m, ok := raw.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("node %q: item_template must be an object, got %T", node.ID, raw)
+	}
+
+	// Marshal to JSON and back to get a proper NodeSpec.
+	data, err := json.Marshal(m)
+	if err != nil {
+		return nil, fmt.Errorf("node %q: marshal item_template: %w", node.ID, err)
+	}
+	var spec NodeSpec
+	if err := json.Unmarshal(data, &spec); err != nil {
+		return nil, fmt.Errorf("node %q: parse item_template: %w", node.ID, err)
+	}
+	return &spec, nil
+}
+
+// expandSpec clones a template spec, assigns IDs, and replaces placeholders.
+func expandSpec(idPrefix string, tmpl *NodeSpec, item map[string]any, childIndex int) *NodeSpec {
+	spec := &NodeSpec{
+		ID:       idPrefix,
+		Type:     tmpl.Type,
+		Props:    replacePlaceholders(deepCopyProps(tmpl.Props), item),
+		Scripts:  copyStrMap(tmpl.Scripts),
+		Computed: copyStrMap(tmpl.Computed),
+	}
+	if len(tmpl.Children) > 0 {
+		spec.Children = make([]*NodeSpec, len(tmpl.Children))
+		for i, child := range tmpl.Children {
+			childID := idPrefix + "-" + strconv.Itoa(i)
+			spec.Children[i] = expandSpec(childID, child, item, i)
+		}
+	}
+	return spec
+}
+
+// itemSuffix returns the ID suffix for an item: the "key" field if present, else the index.
+func itemSuffix(item map[string]any, index int) string {
+	if key, ok := item["key"]; ok {
+		if s, ok := key.(string); ok && s != "" {
+			return s
+		}
+	}
+	return strconv.Itoa(index)
+}
+
+// replaceInString performs {{key}} replacement on a single string.
+func replaceInString(s string, item map[string]any) string {
+	if !strings.Contains(s, "{{") {
+		return s
+	}
+	var b strings.Builder
+	for {
+		start := strings.Index(s, "{{")
+		if start < 0 {
+			b.WriteString(s)
+			break
+		}
+		end := strings.Index(s[start:], "}}")
+		if end < 0 {
+			b.WriteString(s)
+			break
+		}
+		end += start
+
+		b.WriteString(s[:start])
+		key := s[start+2 : end]
+		if item != nil {
+			if val, ok := item[key]; ok {
+				fmt.Fprintf(&b, "%v", val)
+			}
+		}
+		s = s[end+2:]
+	}
+	return b.String()
+}
+
+// replacePlaceholders walks all string values in a map and replaces {{key}} patterns.
+func replacePlaceholders(props, item map[string]any) map[string]any {
+	if props == nil {
+		return nil
+	}
+	for k, v := range props {
+		if s, ok := v.(string); ok {
+			props[k] = replaceInString(s, item)
+		}
+	}
+	return props
+}
+
+// deepCopyProps makes a deep copy of a props map.
+func deepCopyProps(m map[string]any) map[string]any {
+	if m == nil {
+		return nil
+	}
+	return copyMap(m)
+}
+
+// copyStrMap copies a string→string map.
+func copyStrMap(m map[string]string) map[string]string {
+	if m == nil {
+		return nil
+	}
+	return copyStringMap(m)
+}

--- a/internal/dom/template_test.go
+++ b/internal/dom/template_test.go
@@ -1,0 +1,385 @@
+package dom
+
+import (
+	"testing"
+)
+
+func TestReplaceInString(t *testing.T) {
+	tests := []struct {
+		name string
+		s    string
+		item map[string]any
+		want string
+	}{
+		{"no placeholders", "hello", map[string]any{"k": "v"}, "hello"},
+		{"single placeholder", "{{level}}", map[string]any{"level": "INFO"}, "INFO"},
+		{"multiple placeholders", "{{level}}: {{msg}}", map[string]any{"level": "ERROR", "msg": "disk full"}, "ERROR: disk full"},
+		{"placeholder with surrounding text", "[{{level}}] {{msg}}", map[string]any{"level": "WARN", "msg": "retry"}, "[WARN] retry"},
+		{"missing key produces empty", "{{missing}}", map[string]any{"level": "INFO"}, ""},
+		{"int value", "count={{n}}", map[string]any{"n": 42}, "count=42"},
+		{"float value", "pct={{p}}", map[string]any{"p": 3.14}, "pct=3.14"},
+		{"bool value", "ok={{b}}", map[string]any{"b": true}, "ok=true"},
+		{"empty string value", "val={{e}}", map[string]any{"e": ""}, "val="},
+		{"repeated placeholder", "{{x}} and {{x}}", map[string]any{"x": "A"}, "A and A"},
+		{"empty item map", "{{x}}", map[string]any{}, ""},
+		{"nil item map", "{{x}}", nil, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := replaceInString(tt.s, tt.item)
+			if got != tt.want {
+				t.Errorf("replaceInString(%q, %v) = %q, want %q", tt.s, tt.item, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReplacePlaceholders(t *testing.T) {
+	item := map[string]any{"level": "INFO", "msg": "started"}
+
+	props := map[string]any{
+		"content": "{{level}}",
+		"width":   8,
+		"bold":    true,
+		"label":   "{{msg}} log",
+	}
+	got := replacePlaceholders(props, item)
+
+	if got["content"] != "INFO" {
+		t.Errorf("content = %v, want INFO", got["content"])
+	}
+	if got["width"] != 8 {
+		t.Errorf("width = %v, want 8", got["width"])
+	}
+	if got["bold"] != true {
+		t.Errorf("bold = %v, want true", got["bold"])
+	}
+	if got["label"] != "started log" {
+		t.Errorf("label = %v, want 'started log'", got["label"])
+	}
+}
+
+func TestReplacePlaceholders_NilProps(t *testing.T) {
+	got := replacePlaceholders(nil, map[string]any{"k": "v"})
+	if got != nil {
+		t.Errorf("expected nil, got %v", got)
+	}
+}
+
+func TestExpandTemplate_SingleItem(t *testing.T) {
+	tmpl := &NodeSpec{
+		Type:  TypeText,
+		Props: map[string]any{"content": "{{msg}}"},
+	}
+	items := []map[string]any{
+		{"msg": "hello"},
+	}
+
+	specs, err := ExpandTemplate("list", tmpl, items)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(specs) != 1 {
+		t.Fatalf("got %d specs, want 1", len(specs))
+	}
+	s := specs[0]
+	if s.ID != "list-0" {
+		t.Errorf("ID = %q, want %q", s.ID, "list-0")
+	}
+	if s.Type != TypeText {
+		t.Errorf("Type = %q, want %q", s.Type, TypeText)
+	}
+	if s.Props["content"] != "hello" {
+		t.Errorf("content = %v, want %q", s.Props["content"], "hello")
+	}
+}
+
+func TestExpandTemplate_MultipleItems(t *testing.T) {
+	tmpl := &NodeSpec{
+		Type:  TypeText,
+		Props: map[string]any{"content": "{{msg}}"},
+	}
+	items := []map[string]any{
+		{"msg": "one"},
+		{"msg": "two"},
+		{"msg": "three"},
+	}
+
+	specs, err := ExpandTemplate("list", tmpl, items)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(specs) != 3 {
+		t.Fatalf("got %d specs, want 3", len(specs))
+	}
+	for i, want := range []string{"one", "two", "three"} {
+		if specs[i].Props["content"] != want {
+			t.Errorf("specs[%d].content = %v, want %q", i, specs[i].Props["content"], want)
+		}
+		wantID := "list-" + string(rune('0'+i))
+		if specs[i].ID != wantID {
+			t.Errorf("specs[%d].ID = %q, want %q", i, specs[i].ID, wantID)
+		}
+	}
+}
+
+func TestExpandTemplate_WithKeyField(t *testing.T) {
+	tmpl := &NodeSpec{
+		Type:  TypeText,
+		Props: map[string]any{"content": "{{msg}}"},
+	}
+	items := []map[string]any{
+		{"key": "err1", "msg": "disk full"},
+		{"key": "err2", "msg": "timeout"},
+	}
+
+	specs, err := ExpandTemplate("log", tmpl, items)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(specs) != 2 {
+		t.Fatalf("got %d specs, want 2", len(specs))
+	}
+	if specs[0].ID != "log-err1" {
+		t.Errorf("specs[0].ID = %q, want %q", specs[0].ID, "log-err1")
+	}
+	if specs[1].ID != "log-err2" {
+		t.Errorf("specs[1].ID = %q, want %q", specs[1].ID, "log-err2")
+	}
+}
+
+func TestExpandTemplate_NestedChildren(t *testing.T) {
+	tmpl := &NodeSpec{
+		Type:  TypeContainer,
+		Props: map[string]any{"direction": "row"},
+		Children: []*NodeSpec{
+			{Type: TypeText, Props: map[string]any{"content": "{{level}}"}},
+			{Type: TypeText, Props: map[string]any{"content": "{{msg}}"}},
+		},
+	}
+	items := []map[string]any{
+		{"level": "INFO", "msg": "started"},
+	}
+
+	specs, err := ExpandTemplate("log", tmpl, items)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(specs) != 1 {
+		t.Fatalf("got %d specs, want 1", len(specs))
+	}
+
+	root := specs[0]
+	if root.ID != "log-0" {
+		t.Errorf("root.ID = %q, want %q", root.ID, "log-0")
+	}
+	if len(root.Children) != 2 {
+		t.Fatalf("root has %d children, want 2", len(root.Children))
+	}
+	if root.Children[0].ID != "log-0-0" {
+		t.Errorf("child[0].ID = %q, want %q", root.Children[0].ID, "log-0-0")
+	}
+	if root.Children[0].Props["content"] != "INFO" {
+		t.Errorf("child[0].content = %v, want %q", root.Children[0].Props["content"], "INFO")
+	}
+	if root.Children[1].ID != "log-0-1" {
+		t.Errorf("child[1].ID = %q, want %q", root.Children[1].ID, "log-0-1")
+	}
+	if root.Children[1].Props["content"] != "started" {
+		t.Errorf("child[1].content = %v, want %q", root.Children[1].Props["content"], "started")
+	}
+}
+
+func TestExpandTemplate_MissingPlaceholder(t *testing.T) {
+	tmpl := &NodeSpec{
+		Type:  TypeText,
+		Props: map[string]any{"content": "{{missing}}"},
+	}
+	items := []map[string]any{
+		{"other": "value"},
+	}
+
+	specs, err := ExpandTemplate("list", tmpl, items)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if specs[0].Props["content"] != "" {
+		t.Errorf("content = %v, want empty string", specs[0].Props["content"])
+	}
+}
+
+func TestExpandTemplate_NilTemplate(t *testing.T) {
+	_, err := ExpandTemplate("list", nil, []map[string]any{{"k": "v"}})
+	if err == nil {
+		t.Fatal("expected error for nil template")
+	}
+}
+
+func TestExpandTemplate_EmptyItems(t *testing.T) {
+	tmpl := &NodeSpec{
+		Type:  TypeText,
+		Props: map[string]any{"content": "{{msg}}"},
+	}
+	specs, err := ExpandTemplate("list", tmpl, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(specs) != 0 {
+		t.Errorf("got %d specs, want 0", len(specs))
+	}
+
+	specs, err = ExpandTemplate("list", tmpl, []map[string]any{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(specs) != 0 {
+		t.Errorf("got %d specs, want 0", len(specs))
+	}
+}
+
+func TestExpandTemplate_NonStringProps(t *testing.T) {
+	tmpl := &NodeSpec{
+		Type:  TypeText,
+		Props: map[string]any{"content": "{{msg}}", "width": 8, "bold": true},
+	}
+	items := []map[string]any{
+		{"msg": "hello"},
+	}
+
+	specs, err := ExpandTemplate("list", tmpl, items)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if specs[0].Props["width"] != 8 {
+		t.Errorf("width = %v, want 8", specs[0].Props["width"])
+	}
+	if specs[0].Props["bold"] != true {
+		t.Errorf("bold = %v, want true", specs[0].Props["bold"])
+	}
+}
+
+func TestExpandTemplate_PreservesNestedItemTemplate(t *testing.T) {
+	// A template containing a child with its own item_template should preserve it as data.
+	innerTemplate := map[string]any{
+		"type":  "text",
+		"props": map[string]any{"content": "{{inner}}"},
+	}
+	tmpl := &NodeSpec{
+		Type: TypeContainer,
+		Props: map[string]any{
+			"item_template": innerTemplate,
+		},
+	}
+	items := []map[string]any{
+		{"k": "v"},
+	}
+
+	specs, err := ExpandTemplate("list", tmpl, items)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The item_template prop should be preserved (not expanded).
+	it, ok := specs[0].Props["item_template"]
+	if !ok {
+		t.Fatal("item_template prop was removed")
+	}
+	itMap, ok := it.(map[string]any)
+	if !ok {
+		t.Fatalf("item_template is %T, want map[string]any", it)
+	}
+	if itMap["type"] != "text" {
+		t.Errorf("nested item_template type = %v, want text", itMap["type"])
+	}
+}
+
+func TestParseItemTemplate(t *testing.T) {
+	node, err := NewNode("list", TypeContainer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	node.SetProp("item_template", map[string]any{
+		"type": "text",
+		"props": map[string]any{
+			"content": "{{msg}}",
+		},
+	})
+
+	spec, err := ParseItemTemplate(node)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if spec.Type != TypeText {
+		t.Errorf("Type = %q, want %q", spec.Type, TypeText)
+	}
+	if spec.Props["content"] != "{{msg}}" {
+		t.Errorf("content = %v, want {{msg}}", spec.Props["content"])
+	}
+}
+
+func TestParseItemTemplate_WithChildren(t *testing.T) {
+	node, err := NewNode("list", TypeContainer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	node.SetProp("item_template", map[string]any{
+		"type": "container",
+		"children": []any{
+			map[string]any{"type": "text", "props": map[string]any{"content": "{{a}}"}},
+			map[string]any{"type": "text", "props": map[string]any{"content": "{{b}}"}},
+		},
+	})
+
+	spec, err := ParseItemTemplate(node)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(spec.Children) != 2 {
+		t.Fatalf("children = %d, want 2", len(spec.Children))
+	}
+}
+
+func TestParseItemTemplate_Missing(t *testing.T) {
+	node, err := NewNode("list", TypeContainer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = ParseItemTemplate(node)
+	if err == nil {
+		t.Fatal("expected error for missing item_template")
+	}
+}
+
+func TestParseItemTemplate_Invalid(t *testing.T) {
+	node, err := NewNode("list", TypeContainer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	node.SetProp("item_template", "not a map")
+	_, err = ParseItemTemplate(node)
+	if err == nil {
+		t.Fatal("expected error for non-map item_template")
+	}
+}
+
+func TestExpandTemplate_OffsetIndex(t *testing.T) {
+	tmpl := &NodeSpec{
+		Type:  TypeText,
+		Props: map[string]any{"content": "{{msg}}"},
+	}
+	items := []map[string]any{
+		{"msg": "a"},
+		{"msg": "b"},
+	}
+
+	// ExpandTemplateAt with offset=3 should produce IDs list-3, list-4
+	specs, err := ExpandTemplateAt("list", tmpl, items, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if specs[0].ID != "list-3" {
+		t.Errorf("specs[0].ID = %q, want %q", specs[0].ID, "list-3")
+	}
+	if specs[1].ID != "list-4" {
+		t.Errorf("specs[1].ID = %q, want %q", specs[1].ID, "list-4")
+	}
+}

--- a/internal/dom/tree.go
+++ b/internal/dom/tree.go
@@ -256,3 +256,205 @@ func childIndex(parent *Node, childID string) int {
 	}
 	return -1
 }
+
+// SetItems replaces all children of the target node with nodes expanded from
+// the target's item_template prop and the given data items.
+// For list-type nodes, items are set directly as the "items" prop.
+func (t *Tree) SetItems(targetID string, items []map[string]any) error {
+	target := t.Find(targetID)
+	if target == nil {
+		return fmt.Errorf("set_items: node %q not found", targetID)
+	}
+
+	// For list nodes, set items directly as a prop.
+	if target.Type == TypeList {
+		target.SetProp("items", mapSliceToAnySlice(items))
+		return nil
+	}
+
+	// For table nodes, set rows directly as a prop.
+	if target.Type == TypeTable {
+		target.SetProp("rows", mapSliceToAnySlice(items))
+		return nil
+	}
+
+	// For log nodes, set lines directly as a prop.
+	if target.Type == TypeLog {
+		target.SetProp("lines", mapSliceToAnySlice(items))
+		return nil
+	}
+
+	tmpl, err := ParseItemTemplate(target)
+	if err != nil {
+		return fmt.Errorf("set_items: %w", err)
+	}
+
+	if len(items) == 0 {
+		// Clear all children.
+		return t.Replace(targetID, nil)
+	}
+
+	specs, err := ExpandTemplate(targetID, tmpl, items)
+	if err != nil {
+		return fmt.Errorf("set_items: %w", err)
+	}
+	return t.Replace(targetID, specs)
+}
+
+// AppendItems expands template items and appends them as children of the target.
+// For list-type nodes, items are appended to the "items" prop.
+func (t *Tree) AppendItems(targetID string, items []map[string]any) error {
+	target := t.Find(targetID)
+	if target == nil {
+		return fmt.Errorf("append_items: node %q not found", targetID)
+	}
+
+	// For list nodes, append to the items prop.
+	if target.Type == TypeList {
+		existing := getItemsProp(target)
+		existing = append(existing, mapSliceToAnySlice(items)...)
+		target.SetProp("items", existing)
+		return nil
+	}
+
+	// For table nodes, append to the rows prop.
+	if target.Type == TypeTable {
+		existing := getRowsProp(target)
+		existing = append(existing, mapSliceToAnySlice(items)...)
+		target.SetProp("rows", existing)
+		return nil
+	}
+
+	// For log nodes, append to the lines prop.
+	if target.Type == TypeLog {
+		existing := getAnySliceProp(target, "lines")
+		existing = append(existing, mapSliceToAnySlice(items)...)
+		target.SetProp("lines", existing)
+		return nil
+	}
+
+	tmpl, err := ParseItemTemplate(target)
+	if err != nil {
+		return fmt.Errorf("append_items: %w", err)
+	}
+	if len(items) == 0 {
+		return nil
+	}
+
+	offset := len(target.Children)
+	specs, err := ExpandTemplateAt(targetID, tmpl, items, offset)
+	if err != nil {
+		return fmt.Errorf("append_items: %w", err)
+	}
+
+	for _, spec := range specs {
+		node, err := buildNodeFromSpec(spec)
+		if err != nil {
+			return fmt.Errorf("append_items: %w", err)
+		}
+		if err := t.Insert(targetID, node, ""); err != nil {
+			return fmt.Errorf("append_items: %w", err)
+		}
+	}
+	return nil
+}
+
+// RemoveItems removes children from the target by key or index.
+// For container nodes with templates, keys are used to compute child IDs as "{targetID}-{key}".
+// For list-type nodes, keys match the "id" field in the items prop.
+func (t *Tree) RemoveItems(targetID string, keys []string) error {
+	target := t.Find(targetID)
+	if target == nil {
+		return fmt.Errorf("remove_items: node %q not found", targetID)
+	}
+
+	// For list, table, and log nodes, filter items by id.
+	if target.Type == TypeList || target.Type == TypeTable || target.Type == TypeLog {
+		propName := "items"
+		if target.Type == TypeTable {
+			propName = "rows"
+		}
+		if target.Type == TypeLog {
+			propName = "lines"
+		}
+		existing := getAnySliceProp(target, propName)
+		keySet := make(map[string]bool, len(keys))
+		for _, k := range keys {
+			keySet[k] = true
+		}
+		var remaining []any
+		for _, item := range existing {
+			m, ok := item.(map[string]any)
+			if ok {
+				if id, hasID := m["id"]; hasID {
+					if idStr, isStr := id.(string); isStr && keySet[idStr] {
+						continue
+					}
+				}
+			}
+			remaining = append(remaining, item)
+		}
+		// Verify all requested keys were found.
+		for _, k := range keys {
+			found := false
+			for _, item := range existing {
+				if m, ok := item.(map[string]any); ok {
+					if id, hasID := m["id"]; hasID {
+						if idStr, isStr := id.(string); isStr && idStr == k {
+							found = true
+							break
+						}
+					}
+				}
+			}
+			if !found {
+				return fmt.Errorf("remove_items: item %q not found in %s %q", k, target.Type, targetID)
+			}
+		}
+		if remaining == nil {
+			remaining = []any{}
+		}
+		target.SetProp(propName, remaining)
+		return nil
+	}
+
+	for _, key := range keys {
+		childID := targetID + "-" + key
+		if _, err := t.Remove(childID); err != nil {
+			return fmt.Errorf("remove_items: %w", err)
+		}
+	}
+	return nil
+}
+
+// mapSliceToAnySlice converts []map[string]any to []any for prop storage compatibility.
+func mapSliceToAnySlice(items []map[string]any) []any {
+	result := make([]any, len(items))
+	for i, item := range items {
+		result[i] = item
+	}
+	return result
+}
+
+// getItemsProp reads the "items" prop as []any, returning nil if not set.
+func getItemsProp(node *Node) []any {
+	return getAnySliceProp(node, "items")
+}
+
+// getRowsProp reads the "rows" prop as []any, returning nil if not set.
+func getRowsProp(node *Node) []any {
+	return getAnySliceProp(node, "rows")
+}
+
+// getAnySliceProp reads a named prop as []any, returning nil if not set.
+func getAnySliceProp(node *Node, key string) []any {
+	v, ok := node.GetProp(key)
+	if !ok {
+		return nil
+	}
+	items, ok := v.([]any)
+	if !ok {
+		return nil
+	}
+	return items
+}

--- a/internal/dom/tree_test.go
+++ b/internal/dom/tree_test.go
@@ -426,3 +426,693 @@ func TestTreeWalkSingleNode(t *testing.T) {
 		t.Errorf("walk on single node: %v", ids)
 	}
 }
+
+// --- Template-driven tree methods ---
+
+// makeTemplatedTree builds a tree with a container that has an item_template prop.
+func makeTemplatedTree(t *testing.T) *Tree {
+	t.Helper()
+	root, _ := NewNode("root", TypeContainer)
+	list, _ := NewNode("log-list", TypeContainer)
+	list.SetProp("item_template", map[string]any{
+		"type": "container",
+		"props": map[string]any{
+			"direction": "row",
+		},
+		"children": []any{
+			map[string]any{"type": "text", "props": map[string]any{"content": "{{level}}"}},
+			map[string]any{"type": "text", "props": map[string]any{"content": "{{msg}}"}},
+		},
+	})
+	root.Children = append(root.Children, list)
+	list.parent = root
+	tree, err := NewTree(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return tree
+}
+
+func TestTree_SetItems_Basic(t *testing.T) {
+	tree := makeTemplatedTree(t)
+	items := []map[string]any{
+		{"level": "INFO", "msg": "started"},
+		{"level": "ERROR", "msg": "disk full"},
+	}
+
+	if err := tree.SetItems("log-list", items); err != nil {
+		t.Fatal(err)
+	}
+
+	list := tree.Find("log-list")
+	if len(list.Children) != 2 {
+		t.Fatalf("children = %d, want 2", len(list.Children))
+	}
+
+	// Verify first item
+	row0 := list.Children[0]
+	if row0.ID != "log-list-0" {
+		t.Errorf("row0.ID = %q, want %q", row0.ID, "log-list-0")
+	}
+	if len(row0.Children) != 2 {
+		t.Fatalf("row0 children = %d, want 2", len(row0.Children))
+	}
+	if v, _ := row0.Children[0].GetProp("content"); v != "INFO" {
+		t.Errorf("row0.child[0].content = %v, want INFO", v)
+	}
+	if v, _ := row0.Children[1].GetProp("content"); v != "started" {
+		t.Errorf("row0.child[1].content = %v, want 'started'", v)
+	}
+
+	// Verify second item
+	row1 := list.Children[1]
+	if row1.ID != "log-list-1" {
+		t.Errorf("row1.ID = %q, want %q", row1.ID, "log-list-1")
+	}
+
+	// Verify all nodes are indexed
+	if tree.Find("log-list-0") == nil {
+		t.Error("log-list-0 not in index")
+	}
+	if tree.Find("log-list-0-0") == nil {
+		t.Error("log-list-0-0 not in index")
+	}
+}
+
+func TestTree_SetItems_ReplacesExisting(t *testing.T) {
+	tree := makeTemplatedTree(t)
+
+	// First set
+	if err := tree.SetItems("log-list", []map[string]any{
+		{"level": "INFO", "msg": "first"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Second set replaces
+	if err := tree.SetItems("log-list", []map[string]any{
+		{"level": "ERROR", "msg": "second"},
+		{"level": "WARN", "msg": "third"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	list := tree.Find("log-list")
+	if len(list.Children) != 2 {
+		t.Fatalf("children = %d, want 2", len(list.Children))
+	}
+	if v, _ := list.Children[0].Children[1].GetProp("content"); v != "second" {
+		t.Errorf("content = %v, want 'second'", v)
+	}
+
+	// Old nodes should be gone from index
+	// (the first set's node IDs are reused, but let's verify tree is correct)
+	if tree.Find("log-list-0") == nil {
+		t.Error("log-list-0 should exist from second set")
+	}
+}
+
+func TestTree_SetItems_MissingTarget(t *testing.T) {
+	tree := makeTemplatedTree(t)
+	err := tree.SetItems("nonexistent", []map[string]any{{"k": "v"}})
+	if err == nil {
+		t.Fatal("expected error for missing target")
+	}
+}
+
+func TestTree_SetItems_NoTemplate(t *testing.T) {
+	tree := makeTestTree(t)
+	err := tree.SetItems("a", []map[string]any{{"k": "v"}})
+	if err == nil {
+		t.Fatal("expected error for missing item_template")
+	}
+}
+
+func TestTree_SetItems_EmptyItems(t *testing.T) {
+	tree := makeTemplatedTree(t)
+	// First add some items
+	if err := tree.SetItems("log-list", []map[string]any{
+		{"level": "INFO", "msg": "x"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// Then clear with empty items
+	if err := tree.SetItems("log-list", nil); err != nil {
+		t.Fatal(err)
+	}
+	list := tree.Find("log-list")
+	if len(list.Children) != 0 {
+		t.Errorf("children = %d, want 0", len(list.Children))
+	}
+}
+
+func TestTree_SetItems_WithKeys(t *testing.T) {
+	tree := makeTemplatedTree(t)
+	items := []map[string]any{
+		{"key": "err1", "level": "ERROR", "msg": "disk full"},
+		{"key": "err2", "level": "WARN", "msg": "retry"},
+	}
+	if err := tree.SetItems("log-list", items); err != nil {
+		t.Fatal(err)
+	}
+
+	if tree.Find("log-list-err1") == nil {
+		t.Error("log-list-err1 not in index")
+	}
+	if tree.Find("log-list-err2") == nil {
+		t.Error("log-list-err2 not in index")
+	}
+}
+
+func TestTree_AppendItems_Basic(t *testing.T) {
+	tree := makeTemplatedTree(t)
+
+	// Append to empty container
+	if err := tree.AppendItems("log-list", []map[string]any{
+		{"level": "INFO", "msg": "first"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	list := tree.Find("log-list")
+	if len(list.Children) != 1 {
+		t.Fatalf("children = %d, want 1", len(list.Children))
+	}
+
+	// Append more
+	if err := tree.AppendItems("log-list", []map[string]any{
+		{"level": "WARN", "msg": "second"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(list.Children) != 2 {
+		t.Fatalf("children = %d, want 2", len(list.Children))
+	}
+
+	// First item still there
+	if v, _ := list.Children[0].Children[1].GetProp("content"); v != "first" {
+		t.Errorf("child[0] content = %v, want 'first'", v)
+	}
+	// Second item appended
+	if v, _ := list.Children[1].Children[1].GetProp("content"); v != "second" {
+		t.Errorf("child[1] content = %v, want 'second'", v)
+	}
+}
+
+func TestTree_AppendItems_ToExisting(t *testing.T) {
+	tree := makeTemplatedTree(t)
+
+	// Set initial items
+	if err := tree.SetItems("log-list", []map[string]any{
+		{"level": "INFO", "msg": "initial"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Append additional items
+	if err := tree.AppendItems("log-list", []map[string]any{
+		{"level": "ERROR", "msg": "appended"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	list := tree.Find("log-list")
+	if len(list.Children) != 2 {
+		t.Fatalf("children = %d, want 2", len(list.Children))
+	}
+}
+
+func TestTree_RemoveItems_ByKey(t *testing.T) {
+	tree := makeTemplatedTree(t)
+	items := []map[string]any{
+		{"key": "a", "level": "INFO", "msg": "keep"},
+		{"key": "b", "level": "ERROR", "msg": "remove"},
+		{"key": "c", "level": "WARN", "msg": "keep"},
+	}
+	if err := tree.SetItems("log-list", items); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := tree.RemoveItems("log-list", []string{"b"}); err != nil {
+		t.Fatal(err)
+	}
+
+	list := tree.Find("log-list")
+	if len(list.Children) != 2 {
+		t.Fatalf("children = %d, want 2", len(list.Children))
+	}
+	if tree.Find("log-list-b") != nil {
+		t.Error("log-list-b should have been removed")
+	}
+	if tree.Find("log-list-a") == nil {
+		t.Error("log-list-a should still exist")
+	}
+	if tree.Find("log-list-c") == nil {
+		t.Error("log-list-c should still exist")
+	}
+}
+
+func TestTree_RemoveItems_Nonexistent(t *testing.T) {
+	tree := makeTemplatedTree(t)
+	if err := tree.SetItems("log-list", []map[string]any{
+		{"key": "a", "level": "INFO", "msg": "x"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	err := tree.RemoveItems("log-list", []string{"nonexistent"})
+	if err == nil {
+		t.Fatal("expected error for nonexistent key")
+	}
+}
+
+func TestTree_RemoveItems_MissingTarget(t *testing.T) {
+	tree := makeTemplatedTree(t)
+	err := tree.RemoveItems("nonexistent", []string{"a"})
+	if err == nil {
+		t.Fatal("expected error for missing target")
+	}
+}
+
+// makeListTree builds a tree with a list node for testing list-type set_items.
+func makeListTree(t *testing.T) *Tree {
+	t.Helper()
+	root, _ := NewNode("root", TypeContainer)
+	list, _ := NewNode("log-list", TypeList)
+	root.Children = append(root.Children, list)
+	list.parent = root
+
+	tree, err := NewTree(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return tree
+}
+
+func TestTree_SetItems_List_Basic(t *testing.T) {
+	tree := makeListTree(t)
+	items := []map[string]any{
+		{"id": "1", "label": "INFO: server started", "badge": "INFO"},
+		{"id": "2", "label": "ERROR: disk full", "badge": "ERROR"},
+	}
+	if err := tree.SetItems("log-list", items); err != nil {
+		t.Fatal(err)
+	}
+
+	node := tree.Find("log-list")
+	rawItems, ok := node.GetProp("items")
+	if !ok {
+		t.Fatal("items prop not set")
+	}
+	// Items should be stored as []any for PropMapSlice compatibility.
+	anySlice, ok := rawItems.([]any)
+	if !ok {
+		t.Fatalf("items prop is %T, want []any", rawItems)
+	}
+	if len(anySlice) != 2 {
+		t.Fatalf("got %d items, want 2", len(anySlice))
+	}
+	first := anySlice[0].(map[string]any)
+	if first["label"] != "INFO: server started" {
+		t.Errorf("first label = %q, want %q", first["label"], "INFO: server started")
+	}
+}
+
+func TestTree_SetItems_List_ReplacesExisting(t *testing.T) {
+	tree := makeListTree(t)
+	items1 := []map[string]any{
+		{"id": "1", "label": "old item"},
+	}
+	if err := tree.SetItems("log-list", items1); err != nil {
+		t.Fatal(err)
+	}
+	items2 := []map[string]any{
+		{"id": "a", "label": "new item A"},
+		{"id": "b", "label": "new item B"},
+	}
+	if err := tree.SetItems("log-list", items2); err != nil {
+		t.Fatal(err)
+	}
+
+	node := tree.Find("log-list")
+	anySlice := node.Props["items"].([]any)
+	if len(anySlice) != 2 {
+		t.Fatalf("got %d items, want 2", len(anySlice))
+	}
+	if anySlice[0].(map[string]any)["label"] != "new item A" {
+		t.Error("first item not replaced")
+	}
+}
+
+func TestTree_SetItems_List_EmptyClears(t *testing.T) {
+	tree := makeListTree(t)
+	items := []map[string]any{
+		{"id": "1", "label": "item"},
+	}
+	if err := tree.SetItems("log-list", items); err != nil {
+		t.Fatal(err)
+	}
+	if err := tree.SetItems("log-list", nil); err != nil {
+		t.Fatal(err)
+	}
+
+	node := tree.Find("log-list")
+	anySlice := node.Props["items"].([]any)
+	if len(anySlice) != 0 {
+		t.Fatalf("got %d items, want 0", len(anySlice))
+	}
+}
+
+func TestTree_AppendItems_List_Basic(t *testing.T) {
+	tree := makeListTree(t)
+	items := []map[string]any{
+		{"id": "1", "label": "first"},
+	}
+	if err := tree.SetItems("log-list", items); err != nil {
+		t.Fatal(err)
+	}
+	more := []map[string]any{
+		{"id": "2", "label": "second"},
+		{"id": "3", "label": "third"},
+	}
+	if err := tree.AppendItems("log-list", more); err != nil {
+		t.Fatal(err)
+	}
+
+	node := tree.Find("log-list")
+	anySlice := node.Props["items"].([]any)
+	if len(anySlice) != 3 {
+		t.Fatalf("got %d items, want 3", len(anySlice))
+	}
+	if anySlice[2].(map[string]any)["label"] != "third" {
+		t.Error("third item not appended")
+	}
+}
+
+func TestTree_AppendItems_List_ToEmpty(t *testing.T) {
+	tree := makeListTree(t)
+	items := []map[string]any{
+		{"id": "1", "label": "first"},
+	}
+	if err := tree.AppendItems("log-list", items); err != nil {
+		t.Fatal(err)
+	}
+
+	node := tree.Find("log-list")
+	anySlice := node.Props["items"].([]any)
+	if len(anySlice) != 1 {
+		t.Fatalf("got %d items, want 1", len(anySlice))
+	}
+}
+
+func TestTree_RemoveItems_List_ByID(t *testing.T) {
+	tree := makeListTree(t)
+	items := []map[string]any{
+		{"id": "a", "label": "alpha"},
+		{"id": "b", "label": "beta"},
+		{"id": "c", "label": "charlie"},
+	}
+	if err := tree.SetItems("log-list", items); err != nil {
+		t.Fatal(err)
+	}
+	if err := tree.RemoveItems("log-list", []string{"b"}); err != nil {
+		t.Fatal(err)
+	}
+
+	node := tree.Find("log-list")
+	anySlice := node.Props["items"].([]any)
+	if len(anySlice) != 2 {
+		t.Fatalf("got %d items, want 2", len(anySlice))
+	}
+	// Remaining should be a and c.
+	if anySlice[0].(map[string]any)["id"] != "a" {
+		t.Error("expected first item to be 'a'")
+	}
+	if anySlice[1].(map[string]any)["id"] != "c" {
+		t.Error("expected second item to be 'c'")
+	}
+}
+
+func TestTree_RemoveItems_List_Nonexistent(t *testing.T) {
+	tree := makeListTree(t)
+	items := []map[string]any{
+		{"id": "a", "label": "alpha"},
+	}
+	if err := tree.SetItems("log-list", items); err != nil {
+		t.Fatal(err)
+	}
+	err := tree.RemoveItems("log-list", []string{"nonexistent"})
+	if err == nil {
+		t.Fatal("expected error for nonexistent key")
+	}
+}
+
+// --- Table-type set_items tests ---
+
+func makeTableTree(t *testing.T) *Tree {
+	t.Helper()
+	root, _ := NewNode("root", TypeContainer)
+	tbl, _ := NewNode("data-table", TypeTable)
+	root.Children = append(root.Children, tbl)
+	tbl.parent = root
+
+	tree, err := NewTree(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return tree
+}
+
+func TestTree_SetItems_Table_Basic(t *testing.T) {
+	tree := makeTableTree(t)
+	rows := []map[string]any{
+		{"name": "Alice", "age": 30},
+		{"name": "Bob", "age": 25},
+	}
+	if err := tree.SetItems("data-table", rows); err != nil {
+		t.Fatal(err)
+	}
+
+	node := tree.Find("data-table")
+	rawRows, ok := node.GetProp("rows")
+	if !ok {
+		t.Fatal("rows prop not set")
+	}
+	anySlice, ok := rawRows.([]any)
+	if !ok {
+		t.Fatalf("rows prop is %T, want []any", rawRows)
+	}
+	if len(anySlice) != 2 {
+		t.Fatalf("got %d rows, want 2", len(anySlice))
+	}
+	first := anySlice[0].(map[string]any)
+	if first["name"] != "Alice" {
+		t.Errorf("first name = %v, want Alice", first["name"])
+	}
+}
+
+func TestTree_AppendItems_Table_Basic(t *testing.T) {
+	tree := makeTableTree(t)
+	if err := tree.SetItems("data-table", []map[string]any{
+		{"name": "Alice"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := tree.AppendItems("data-table", []map[string]any{
+		{"name": "Bob"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	node := tree.Find("data-table")
+	anySlice := node.Props["rows"].([]any)
+	if len(anySlice) != 2 {
+		t.Fatalf("got %d rows, want 2", len(anySlice))
+	}
+}
+
+func TestTree_RemoveItems_Table_ByID(t *testing.T) {
+	tree := makeTableTree(t)
+	if err := tree.SetItems("data-table", []map[string]any{
+		{"id": "a", "name": "Alice"},
+		{"id": "b", "name": "Bob"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := tree.RemoveItems("data-table", []string{"a"}); err != nil {
+		t.Fatal(err)
+	}
+
+	node := tree.Find("data-table")
+	anySlice := node.Props["rows"].([]any)
+	if len(anySlice) != 1 {
+		t.Fatalf("got %d rows, want 1", len(anySlice))
+	}
+	if anySlice[0].(map[string]any)["name"] != "Bob" {
+		t.Error("expected remaining row to be Bob")
+	}
+}
+
+// --- Log-type set_items tests ---
+
+func makeLogTree(t *testing.T) *Tree {
+	t.Helper()
+	root, _ := NewNode("root", TypeContainer)
+	logNode, _ := NewNode("mission-log", TypeLog)
+	root.Children = append(root.Children, logNode)
+	logNode.parent = root
+
+	tree, err := NewTree(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return tree
+}
+
+func TestTree_SetItems_Log_Basic(t *testing.T) {
+	tree := makeLogTree(t)
+	lines := []map[string]any{
+		{"id": "1", "text": "Engines nominal", "level": "info"},
+		{"id": "2", "text": "Fuel pressure low", "level": "warn"},
+	}
+	if err := tree.SetItems("mission-log", lines); err != nil {
+		t.Fatal(err)
+	}
+
+	node := tree.Find("mission-log")
+	rawLines, ok := node.GetProp("lines")
+	if !ok {
+		t.Fatal("lines prop not set")
+	}
+	anySlice, ok := rawLines.([]any)
+	if !ok {
+		t.Fatalf("lines prop is %T, want []any", rawLines)
+	}
+	if len(anySlice) != 2 {
+		t.Fatalf("got %d lines, want 2", len(anySlice))
+	}
+	first := anySlice[0].(map[string]any)
+	if first["text"] != "Engines nominal" {
+		t.Errorf("first text = %q, want %q", first["text"], "Engines nominal")
+	}
+}
+
+func TestTree_SetItems_Log_ReplacesExisting(t *testing.T) {
+	tree := makeLogTree(t)
+	if err := tree.SetItems("mission-log", []map[string]any{
+		{"id": "1", "text": "old line"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := tree.SetItems("mission-log", []map[string]any{
+		{"id": "a", "text": "new line A"},
+		{"id": "b", "text": "new line B"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	node := tree.Find("mission-log")
+	anySlice := node.Props["lines"].([]any)
+	if len(anySlice) != 2 {
+		t.Fatalf("got %d lines, want 2", len(anySlice))
+	}
+	if anySlice[0].(map[string]any)["text"] != "new line A" {
+		t.Error("first line not replaced")
+	}
+}
+
+func TestTree_SetItems_Log_EmptyClears(t *testing.T) {
+	tree := makeLogTree(t)
+	if err := tree.SetItems("mission-log", []map[string]any{
+		{"id": "1", "text": "line"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := tree.SetItems("mission-log", nil); err != nil {
+		t.Fatal(err)
+	}
+
+	node := tree.Find("mission-log")
+	anySlice := node.Props["lines"].([]any)
+	if len(anySlice) != 0 {
+		t.Fatalf("got %d lines, want 0", len(anySlice))
+	}
+}
+
+func TestTree_AppendItems_Log_Basic(t *testing.T) {
+	tree := makeLogTree(t)
+	if err := tree.SetItems("mission-log", []map[string]any{
+		{"id": "1", "text": "first"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := tree.AppendItems("mission-log", []map[string]any{
+		{"id": "2", "text": "second"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	node := tree.Find("mission-log")
+	anySlice := node.Props["lines"].([]any)
+	if len(anySlice) != 2 {
+		t.Fatalf("got %d lines, want 2", len(anySlice))
+	}
+	if anySlice[1].(map[string]any)["text"] != "second" {
+		t.Error("second line not appended")
+	}
+}
+
+func TestTree_AppendItems_Log_ToEmpty(t *testing.T) {
+	tree := makeLogTree(t)
+	if err := tree.AppendItems("mission-log", []map[string]any{
+		{"id": "1", "text": "first"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	node := tree.Find("mission-log")
+	anySlice := node.Props["lines"].([]any)
+	if len(anySlice) != 1 {
+		t.Fatalf("got %d lines, want 1", len(anySlice))
+	}
+}
+
+func TestTree_RemoveItems_Log_ByID(t *testing.T) {
+	tree := makeLogTree(t)
+	if err := tree.SetItems("mission-log", []map[string]any{
+		{"id": "a", "text": "alpha"},
+		{"id": "b", "text": "beta"},
+		{"id": "c", "text": "charlie"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := tree.RemoveItems("mission-log", []string{"b"}); err != nil {
+		t.Fatal(err)
+	}
+
+	node := tree.Find("mission-log")
+	anySlice := node.Props["lines"].([]any)
+	if len(anySlice) != 2 {
+		t.Fatalf("got %d lines, want 2", len(anySlice))
+	}
+	if anySlice[0].(map[string]any)["id"] != "a" {
+		t.Error("expected first item to be 'a'")
+	}
+	if anySlice[1].(map[string]any)["id"] != "c" {
+		t.Error("expected second item to be 'c'")
+	}
+}
+
+func TestTree_RemoveItems_Log_Nonexistent(t *testing.T) {
+	tree := makeLogTree(t)
+	if err := tree.SetItems("mission-log", []map[string]any{
+		{"id": "a", "text": "alpha"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	err := tree.RemoveItems("mission-log", []string{"nonexistent"})
+	if err == nil {
+		t.Fatal("expected error for nonexistent key")
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -8,10 +8,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"log/slog"
 	"sync"
 	"time"
 
 	"github.com/joncooper/imagine-tui/internal/dom"
+	"github.com/joncooper/imagine-tui/internal/widget"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -20,14 +23,65 @@ type ToolHandler = func(context.Context, *mcp.CallToolRequest) (*mcp.CallToolRes
 
 // Server wraps the MCP server with a DOM tree, event queue, and snapshot store.
 type Server struct {
-	mu       sync.RWMutex
-	tree     *dom.Tree
-	events   *dom.EventQueue
-	snaps    *dom.SnapshotStore
-	srv      *mcp.Server
-	handlers map[string]ToolHandler // tool name -> handler, for direct invocation
-	shutdown chan struct{}
+	mu         sync.RWMutex
+	tree       *dom.Tree
+	events     *dom.EventQueue
+	snaps      *dom.SnapshotStore
+	srv        *mcp.Server
+	handlers   map[string]ToolHandler // tool name -> handler, for direct invocation
+	shutdown   chan struct{}
+	onMutation func() // called after DOM-mutating operations (patch, replace, restore)
+	logger     *slog.Logger
 }
+
+// SetLogger sets the structured logger for the server.
+func (s *Server) SetLogger(l *slog.Logger) {
+	s.logger = l
+}
+
+// SetOnMutation registers a callback that fires after successful DOM mutations.
+// Used to notify BubbleTea of DOM changes so it can re-render.
+func (s *Server) SetOnMutation(fn func()) {
+	s.onMutation = fn
+}
+
+// notifyMutation calls the mutation callback if one is registered.
+func (s *Server) notifyMutation() {
+	if s.onMutation != nil {
+		s.onMutation()
+	}
+}
+
+// serverInstructions is sent to clients during MCP initialization.
+// This is the primary way the LLM learns how to use imagine-tui — no CLAUDE.md required.
+const serverInstructions = `imagine-tui is an MCP server that renders interactive terminal UIs.
+
+## Getting started
+1. Call describe_widgets to discover available widget types, their props, and events.
+2. Call layout to define your UI structure as a tree of widgets.
+3. Call set_items to populate list or table widgets with data.
+4. Call await_event to wait for user interaction, then respond by updating the UI.
+
+## Key tools
+- describe_widgets: Discover widget types (call this first!)
+- describe_scripting: Learn the reactive scripting system (hooks, $ API, computed props, emit)
+- layout: Define UI structure (container, text, list, table, button, input, etc.)
+- set_items / append_items / remove_items: Efficiently populate list, table, and log widgets with data
+- patch: Incremental DOM updates (update props, insert/remove nodes)
+- await_event: Long-poll for user events (click, select, submit, change)
+- query: Read current node state
+- snapshot / restore: Save and restore UI checkpoints
+
+## Widget overview
+Widgets include: container (layout), text, list (navigable with up/down/enter),
+table (sortable, expandable rows), button, input, textarea, select, code, log, diff.
+Call describe_widgets for full details on any widget type.
+
+## Data pattern
+For data-heavy UIs, use layout + set_items instead of generating large JSON patches.
+Define the structure once with layout, then send compact data arrays with set_items.
+For log widgets, use append_items to add new lines without resending the entire array.
+This is 10-20x fewer tokens than raw DOM manipulation.`
 
 // NewServer creates a new MCP server with all tool declarations registered.
 // It initializes a minimal DOM tree with a single root container node.
@@ -47,12 +101,15 @@ func NewServer() (*Server, error) {
 		snaps:    dom.NewSnapshotStore(),
 		handlers: make(map[string]ToolHandler),
 		shutdown: make(chan struct{}),
+		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
 
 	s.srv = mcp.NewServer(&mcp.Implementation{
 		Name:    "imagine-tui",
 		Version: "0.1.0",
-	}, nil)
+	}, &mcp.ServerOptions{
+		Instructions: serverInstructions,
+	})
 
 	s.registerTools()
 	return s, nil
@@ -136,6 +193,20 @@ type queryInput struct {
 	IDs []string `json:"ids"`
 }
 
+type layoutInput struct {
+	Tree json.RawMessage `json:"tree"`
+}
+
+type setItemsInput struct {
+	Target string          `json:"target"`
+	Items  json.RawMessage `json:"items"`
+}
+
+type removeItemsInput struct {
+	Target string          `json:"target"`
+	Keys   json.RawMessage `json:"keys"`
+}
+
 // CallTool invokes a tool handler directly by name. Useful for integration
 // testing without going through the full MCP transport.
 func (s *Server) CallTool(ctx context.Context, name string, args map[string]any) (*mcp.CallToolResult, error) {
@@ -168,6 +239,12 @@ func (s *Server) registerTools() {
 	s.addTool(snapshotTool(), s.handleSnapshot)
 	s.addTool(restoreTool(), s.handleRestore)
 	s.addTool(queryTool(), s.handleQuery)
+	s.addTool(layoutTool(), s.handleLayout)
+	s.addTool(setItemsTool(), s.handleSetItems)
+	s.addTool(appendItemsTool(), s.handleAppendItems)
+	s.addTool(removeItemsTool(), s.handleRemoveItems)
+	s.addTool(describeWidgetsTool(), s.handleDescribeWidgets)
+	s.addTool(describeScriptingTool(), s.handleDescribeScripting)
 }
 
 func (s *Server) addTool(tool *mcp.Tool, handler ToolHandler) {
@@ -178,9 +255,9 @@ func (s *Server) addTool(tool *mcp.Tool, handler ToolHandler) {
 func patchTool() *mcp.Tool {
 	return &mcp.Tool{
 		Name:        "patch",
-		Description: "Apply an ordered list of atomic operations to the TUI DOM tree",
+		Description: "Apply an ordered list of atomic operations to the TUI DOM tree. Supported ops: update, insert, remove, move, append.",
 		InputSchema: inputSchema(
-			prop("ops", "array", "Ordered list of patch operations (update, insert, remove, move)"),
+			prop("ops", "array", "Ordered list of patch operations (update, insert, remove, move, append). Append op: {op: \"append\", id: \"node-id\", prop: \"lines\", values: [...]}"),
 			"ops",
 		),
 	}
@@ -299,13 +376,19 @@ func (s *Server) handlePatch(ctx context.Context, req *mcp.CallToolRequest) (*mc
 		return errResult(fmt.Sprintf("invalid ops: %v", err)), nil
 	}
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.logger.Info("patch", "op_count", len(ops))
 
-	if err := s.tree.Patch(ops); err != nil {
+	s.mu.Lock()
+	err = s.tree.Patch(ops)
+	s.mu.Unlock()
+
+	if err != nil {
+		s.logger.Error("patch: failed", "error", err)
 		return errResult(err.Error()), nil
 	}
 
+	s.logger.Info("patch: success")
+	s.notifyMutation()
 	return jsonResult(map[string]any{"ok": true})
 }
 
@@ -320,35 +403,52 @@ func (s *Server) handleReplace(ctx context.Context, req *mcp.CallToolRequest) (*
 	}
 
 	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	if input.TargetID == "" {
 		// Whole-tree replacement.
 		if len(input.Tree) == 0 {
+			s.mu.Unlock()
 			return errResult("replace requires either target_id or tree"), nil
 		}
 		var spec dom.NodeSpec
 		if err := json.Unmarshal(input.Tree, &spec); err != nil {
+			s.mu.Unlock()
+			s.logger.Error("replace: invalid tree spec", "error", err)
 			return errResult(fmt.Sprintf("invalid tree spec: %v", err)), nil
 		}
+		childCount := len(spec.Children)
+		s.logger.Info("replace: whole tree", "root_id", spec.ID, "root_type", spec.Type, "children", childCount)
 		if err := s.tree.ReplaceTree(&spec); err != nil {
+			s.mu.Unlock()
+			s.logger.Error("replace: ReplaceTree failed", "error", err)
 			return errResult(err.Error()), nil
 		}
-		return jsonResult(map[string]any{"ok": true})
+		nodeCount := 0
+		s.tree.Walk(func(n *dom.Node) bool { nodeCount++; return true })
+		summary := s.tree.Summary()
+		s.mu.Unlock()
+		s.logger.Info("replace: success", "node_count", nodeCount, "tree_summary", summary)
+		s.notifyMutation()
+		return jsonResult(map[string]any{"ok": true, "node_count": nodeCount})
 	}
 
 	// Subtree replacement.
 	if len(input.Children) == 0 {
+		s.mu.Unlock()
 		return errResult("replace with target_id requires children"), nil
 	}
 	var specs []*dom.NodeSpec
 	if err := json.Unmarshal(input.Children, &specs); err != nil {
+		s.mu.Unlock()
 		return errResult(fmt.Sprintf("invalid children: %v", err)), nil
 	}
 	if err := s.tree.Replace(input.TargetID, specs); err != nil {
+		s.mu.Unlock()
 		return errResult(err.Error()), nil
 	}
+	s.mu.Unlock()
 
+	s.notifyMutation()
 	return jsonResult(map[string]any{"ok": true})
 }
 
@@ -431,12 +531,14 @@ func (s *Server) handleRestore(ctx context.Context, req *mcp.CallToolRequest) (*
 	}
 
 	s.mu.Lock()
-	defer s.mu.Unlock()
+	err := s.snaps.Restore(input.Name, s.tree)
+	s.mu.Unlock()
 
-	if err := s.snaps.Restore(input.Name, s.tree); err != nil {
+	if err != nil {
 		return errResult(err.Error()), nil
 	}
 
+	s.notifyMutation()
 	return jsonResult(map[string]any{"ok": true, "restored": input.Name})
 }
 
@@ -453,6 +555,8 @@ func (s *Server) handleQuery(ctx context.Context, req *mcp.CallToolRequest) (*mc
 		return errResult("missing required parameter: ids"), nil
 	}
 
+	s.logger.Info("query", "ids", input.IDs, "tree_summary", s.tree.Summary())
+
 	s.mu.Lock()
 	results, errs := s.tree.Query(input.IDs)
 	s.mu.Unlock()
@@ -466,9 +570,344 @@ func (s *Server) handleQuery(ctx context.Context, req *mcp.CallToolRequest) (*mc
 			errStrs[i] = e.Error()
 		}
 		resp["errors"] = errStrs
+		s.logger.Warn("query: some IDs not found", "errors", errStrs)
 	}
 
 	return jsonResult(resp)
+}
+
+// --- Template-driven data tools ---
+
+func layoutTool() *mcp.Tool {
+	return &mcp.Tool{
+		Name:        "layout",
+		Description: "Define or replace the UI structure. Container nodes may include an item_template prop for use with set_items/append_items. Idempotent.",
+		InputSchema: inputSchema(
+			prop("tree", "object", "Full tree spec. Container nodes may include an item_template prop with {{key}} placeholders."),
+			"tree",
+		),
+	}
+}
+
+func setItemsTool() *mcp.Tool {
+	return &mcp.Tool{
+		Name:        "set_items",
+		Description: "Populate a list, table, log, or templated container with data. For list nodes: items are {id, label, badge, style}. For table nodes: items are row objects. For log nodes: items are {text, level, timestamp}. For containers with item_template: items are expanded through the template. Replaces all existing items.",
+		InputSchema: inputSchema(
+			mergeProps(
+				prop("target", "string", "ID of the list node or container with item_template"),
+				prop("items", "array", "Array of data objects. For lists: {id, label, badge, style}. For templates: keys map to {{key}} placeholders."),
+			),
+			"target", "items",
+		),
+	}
+}
+
+func appendItemsTool() *mcp.Tool {
+	return &mcp.Tool{
+		Name:        "append_items",
+		Description: "Append data items to a list, table, log, or templated container without replacing existing items.",
+		InputSchema: inputSchema(
+			mergeProps(
+				prop("target", "string", "ID of the list node or container with item_template"),
+				prop("items", "array", "Array of data objects to append"),
+			),
+			"target", "items",
+		),
+	}
+}
+
+func removeItemsTool() *mcp.Tool {
+	return &mcp.Tool{
+		Name:        "remove_items",
+		Description: "Remove items from a list, table, log, or templated container. For list/table/log nodes: keys match item id fields. For containers: keys compute child IDs as {target}-{key}.",
+		InputSchema: inputSchema(
+			mergeProps(
+				prop("target", "string", "ID of the list node or container"),
+				prop("keys", "array", "Array of item keys to remove"),
+			),
+			"target", "keys",
+		),
+	}
+}
+
+func describeWidgetsTool() *mcp.Tool {
+	return &mcp.Tool{
+		Name:        "describe_widgets",
+		Description: "List available widget types with their props, events, and capabilities. Call this before building a UI to discover what widgets you can use. Optionally filter by type.",
+		InputSchema: inputSchema(
+			mergeProps(
+				prop("type", "string", "Optional: filter to a specific widget type (e.g. \"list\", \"table\")"),
+			),
+		),
+	}
+}
+
+type describeWidgetsInput struct {
+	Type string `json:"type"`
+}
+
+func (s *Server) handleDescribeWidgets(_ context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	var input describeWidgetsInput
+	if err := unmarshalArgs(req, &input); err != nil {
+		return errResult(err.Error()), nil
+	}
+
+	if input.Type != "" {
+		catalog := widget.CatalogMap()
+		info, ok := catalog[input.Type]
+		if !ok {
+			return errResult(fmt.Sprintf("unknown widget type %q", input.Type)), nil
+		}
+		return jsonResult(info)
+	}
+
+	return jsonResult(widget.Catalog())
+}
+
+func describeScriptingTool() *mcp.Tool {
+	return &mcp.Tool{
+		Name:        "describe_scripting",
+		Description: "Describe the reactive scripting system: lifecycle hooks, the $ node API, computed props, emit, and state. Call this to learn how to add client-side logic to widgets.",
+		InputSchema: inputSchema(nil),
+	}
+}
+
+// scriptingInfo is the static response for describe_scripting.
+type scriptingInfo struct {
+	Overview  string       `json:"overview"`
+	Hooks     []hookInfo   `json:"hooks"`
+	DollarAPI []apiEntry   `json:"dollar_api"`
+	Globals   []apiEntry   `json:"globals"`
+	Computed  computedInfo `json:"computed_props"`
+	Sandbox   sandboxInfo  `json:"sandbox"`
+	Examples  []example    `json:"examples"`
+}
+
+type hookInfo struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+type apiEntry struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	ReadOnly    bool   `json:"read_only,omitempty"`
+}
+
+type computedInfo struct {
+	Description string `json:"description"`
+	Declaration string `json:"declaration"`
+}
+
+type sandboxInfo struct {
+	Description string   `json:"description"`
+	Blocked     []string `json:"blocked"`
+}
+
+type example struct {
+	Title string `json:"title"`
+	Code  string `json:"code"`
+}
+
+func scriptingCatalog() *scriptingInfo {
+	return &scriptingInfo{
+		Overview: "Every DOM node can have JavaScript hooks and computed props. Scripts run in a sandboxed goja (ES5.1) VM. The only way to communicate outside the sandbox is via emit().",
+		Hooks: []hookInfo{
+			{Name: "on_mount", Description: "Runs once when the node enters the DOM"},
+			{Name: "on_change", Description: "Runs when the node's value prop changes (inputs, selects)"},
+			{Name: "on_event", Description: "Runs when a child node emits an event (bubbles up)"},
+			{Name: "on_focus", Description: "Runs when the node receives focus"},
+			{Name: "on_blur", Description: "Runs when the node loses focus"},
+			{Name: "on_key", Description: "Runs on keypress when the node is focused"},
+		},
+		DollarAPI: []apiEntry{
+			{Name: "$", Description: "Current node proxy. Read/write props: $.value, $.text, $.style, $.visible, $.rows, $.props.{key}"},
+			{Name: "$.id", Description: "Node ID", ReadOnly: true},
+			{Name: "$.type", Description: "Node type", ReadOnly: true},
+			{Name: "$.value", Description: "The node's value (for inputs, textareas, selects)"},
+			{Name: "$.props", Description: "All props as an object — read or write individual keys"},
+			{Name: "$.style", Description: "Style token string"},
+			{Name: "$.text", Description: "Text content (alias for content prop)"},
+			{Name: "$.visible", Description: "Show/hide the node (bool)"},
+			{Name: "$.children", Description: "Child node proxies (read-only array)", ReadOnly: true},
+			{Name: "$.rows", Description: "Table rows array"},
+			{Name: "$('id')", Description: "Look up any node by ID and return a proxy with the same read/write API"},
+		},
+		Globals: []apiEntry{
+			{Name: "emit('local', patchOps)", Description: "Apply a DOM patch synchronously from within the script (no MCP round-trip)"},
+			{Name: "emit('claude', data)", Description: "Queue an event for the MCP client (delivered via await_event)"},
+			{Name: "state", Description: "Per-node persistent JavaScript object — survives across hook invocations"},
+			{Name: "event", Description: "The hook payload object (e.g., key info for on_key, value for on_change). Only defined during hook execution."},
+			{Name: "debug(...args)", Description: "Log to the server's debug output (not visible in TUI)"},
+		},
+		Computed: computedInfo{
+			Description: "Computed props are reactive expressions that auto-update when dependencies change. Declare them in the node's computed map. Dependencies are tracked automatically via $ access.",
+			Declaration: "In node spec: {\"computed\": {\"display_text\": \"return $.value.toUpperCase()\"}}",
+		},
+		Sandbox: sandboxInfo{
+			Description: "Scripts run in a locked-down ES5.1 sandbox. The only way to affect the outside world is via emit().",
+			Blocked:     []string{"require", "fetch", "XMLHttpRequest", "setTimeout", "setInterval", "console.log", "console.warn", "console.error"},
+		},
+		Examples: []example{
+			{
+				Title: "Computed prop: live character count",
+				Code:  `{"computed": {"char_count": "return 'Characters: ' + ($.value || '').length"}}`,
+			},
+			{
+				Title: "on_change hook: filter a list when input changes",
+				Code:  `{"scripts": {"on_change": "emit('claude', {action: 'filter', query: $.value})"}}`,
+			},
+		},
+	}
+}
+
+func (s *Server) handleDescribeScripting(_ context.Context, _ *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return jsonResult(scriptingCatalog())
+}
+
+func (s *Server) handleLayout(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	if s.IsShutdown() {
+		return errResult("server is shutting down"), nil
+	}
+
+	var input layoutInput
+	if err := unmarshalArgs(req, &input); err != nil {
+		return errResult(err.Error()), nil
+	}
+	if len(input.Tree) == 0 {
+		return errResult("missing required parameter: tree"), nil
+	}
+
+	var spec dom.NodeSpec
+	if err := json.Unmarshal(input.Tree, &spec); err != nil {
+		s.logger.Error("layout: invalid tree spec", "error", err)
+		return errResult(fmt.Sprintf("invalid tree spec: %v", err)), nil
+	}
+
+	s.logger.Info("layout", "root_id", spec.ID, "root_type", spec.Type, "children", len(spec.Children))
+
+	s.mu.Lock()
+	if err := s.tree.ReplaceTree(&spec); err != nil {
+		s.mu.Unlock()
+		s.logger.Error("layout: ReplaceTree failed", "error", err)
+		return errResult(err.Error()), nil
+	}
+	nodeCount := 0
+	s.tree.Walk(func(n *dom.Node) bool { nodeCount++; return true })
+	s.mu.Unlock()
+
+	s.logger.Info("layout: success", "node_count", nodeCount)
+	s.notifyMutation()
+	return jsonResult(map[string]any{"ok": true, "node_count": nodeCount})
+}
+
+func (s *Server) handleSetItems(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	if s.IsShutdown() {
+		return errResult("server is shutting down"), nil
+	}
+
+	var input setItemsInput
+	if err := unmarshalArgs(req, &input); err != nil {
+		return errResult(err.Error()), nil
+	}
+	if input.Target == "" {
+		return errResult("missing required parameter: target"), nil
+	}
+
+	var items []map[string]any
+	if len(input.Items) > 0 {
+		if err := json.Unmarshal(input.Items, &items); err != nil {
+			return errResult(fmt.Sprintf("invalid items: %v", err)), nil
+		}
+	}
+
+	s.logger.Info("set_items", "target", input.Target, "item_count", len(items))
+
+	s.mu.Lock()
+	err := s.tree.SetItems(input.Target, items)
+	s.mu.Unlock()
+
+	if err != nil {
+		s.logger.Error("set_items: failed", "error", err)
+		return errResult(err.Error()), nil
+	}
+
+	s.logger.Info("set_items: success")
+	s.notifyMutation()
+	return jsonResult(map[string]any{"ok": true, "count": len(items)})
+}
+
+func (s *Server) handleAppendItems(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	if s.IsShutdown() {
+		return errResult("server is shutting down"), nil
+	}
+
+	var input setItemsInput
+	if err := unmarshalArgs(req, &input); err != nil {
+		return errResult(err.Error()), nil
+	}
+	if input.Target == "" {
+		return errResult("missing required parameter: target"), nil
+	}
+
+	var items []map[string]any
+	if len(input.Items) > 0 {
+		if err := json.Unmarshal(input.Items, &items); err != nil {
+			return errResult(fmt.Sprintf("invalid items: %v", err)), nil
+		}
+	}
+
+	s.logger.Info("append_items", "target", input.Target, "item_count", len(items))
+
+	s.mu.Lock()
+	err := s.tree.AppendItems(input.Target, items)
+	s.mu.Unlock()
+
+	if err != nil {
+		s.logger.Error("append_items: failed", "error", err)
+		return errResult(err.Error()), nil
+	}
+
+	s.logger.Info("append_items: success")
+	s.notifyMutation()
+	return jsonResult(map[string]any{"ok": true, "count": len(items)})
+}
+
+func (s *Server) handleRemoveItems(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	if s.IsShutdown() {
+		return errResult("server is shutting down"), nil
+	}
+
+	var input removeItemsInput
+	if err := unmarshalArgs(req, &input); err != nil {
+		return errResult(err.Error()), nil
+	}
+	if input.Target == "" {
+		return errResult("missing required parameter: target"), nil
+	}
+
+	var keys []string
+	if len(input.Keys) > 0 {
+		if err := json.Unmarshal(input.Keys, &keys); err != nil {
+			return errResult(fmt.Sprintf("invalid keys: %v", err)), nil
+		}
+	}
+
+	s.logger.Info("remove_items", "target", input.Target, "key_count", len(keys))
+
+	s.mu.Lock()
+	err := s.tree.RemoveItems(input.Target, keys)
+	s.mu.Unlock()
+
+	if err != nil {
+		s.logger.Error("remove_items: failed", "error", err)
+		return errResult(err.Error()), nil
+	}
+
+	s.logger.Info("remove_items: success")
+	s.notifyMutation()
+	return jsonResult(map[string]any{"ok": true, "removed": len(keys)})
 }
 
 // --- Helpers ---

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -171,6 +171,9 @@ func TestServerListsAllTools(t *testing.T) {
 	expected := map[string]bool{
 		"patch": false, "replace": false, "await_event": false,
 		"snapshot": false, "restore": false, "query": false,
+		"layout": false, "set_items": false, "append_items": false, "remove_items": false,
+		"describe_widgets":   false,
+		"describe_scripting": false,
 	}
 
 	for _, tool := range result.Tools {
@@ -1199,6 +1202,18 @@ func callHandlerDirect(t *testing.T, s *Server, toolName string, args map[string
 		result, err = s.handleRestore(ctx, req)
 	case "query":
 		result, err = s.handleQuery(ctx, req)
+	case "layout":
+		result, err = s.handleLayout(ctx, req)
+	case "set_items":
+		result, err = s.handleSetItems(ctx, req)
+	case "append_items":
+		result, err = s.handleAppendItems(ctx, req)
+	case "remove_items":
+		result, err = s.handleRemoveItems(ctx, req)
+	case "describe_widgets":
+		result, err = s.handleDescribeWidgets(ctx, req)
+	case "describe_scripting":
+		result, err = s.handleDescribeScripting(ctx, req)
 	default:
 		t.Fatalf("unknown tool: %s", toolName)
 	}
@@ -1207,4 +1222,573 @@ func callHandlerDirect(t *testing.T, s *Server, toolName string, args map[string
 		t.Fatalf("tool %q returned error: %v", toolName, err)
 	}
 	return result
+}
+
+// --- Mutation callback tests ---
+
+func TestOnMutationCallback(t *testing.T) {
+	t.Run("patch fires callback on success", func(t *testing.T) {
+		e := setupWithTree(t)
+		var mu sync.Mutex
+		calls := 0
+		e.server.SetOnMutation(func() {
+			mu.Lock()
+			calls++
+			mu.Unlock()
+		})
+
+		e.call(t, "patch", map[string]any{
+			"ops": []any{
+				map[string]any{"op": "update", "id": "header", "props": map[string]any{"text": "Updated"}},
+			},
+		})
+
+		mu.Lock()
+		defer mu.Unlock()
+		if calls != 1 {
+			t.Fatalf("expected 1 mutation callback, got %d", calls)
+		}
+	})
+
+	t.Run("patch does not fire callback on error", func(t *testing.T) {
+		e := setup(t)
+		calls := 0
+		e.server.SetOnMutation(func() { calls++ })
+
+		r := e.call(t, "patch", map[string]any{
+			"ops": []any{
+				map[string]any{"op": "update", "id": "nonexistent", "props": map[string]any{"text": "x"}},
+			},
+		})
+
+		text := resultText(t, r)
+		if !strings.Contains(text, "not found") {
+			t.Fatalf("expected error about not found, got: %s", text)
+		}
+		if calls != 0 {
+			t.Fatalf("expected 0 mutation callbacks on error, got %d", calls)
+		}
+	})
+
+	t.Run("replace whole tree fires callback", func(t *testing.T) {
+		e := setup(t)
+		calls := 0
+		e.server.SetOnMutation(func() { calls++ })
+
+		e.call(t, "replace", map[string]any{
+			"tree": map[string]any{
+				"id":   "root",
+				"type": "container",
+				"children": []any{
+					map[string]any{"id": "child", "type": "text", "props": map[string]any{"content": "hi"}},
+				},
+			},
+		})
+
+		if calls != 1 {
+			t.Fatalf("expected 1 mutation callback, got %d", calls)
+		}
+	})
+
+	t.Run("replace subtree fires callback", func(t *testing.T) {
+		e := setupWithTree(t)
+		calls := 0
+		e.server.SetOnMutation(func() { calls++ })
+
+		e.call(t, "replace", map[string]any{
+			"target_id": "main",
+			"children": []any{
+				map[string]any{"id": "new_child", "type": "text", "props": map[string]any{"content": "replaced"}},
+			},
+		})
+
+		if calls != 1 {
+			t.Fatalf("expected 1 mutation callback, got %d", calls)
+		}
+	})
+
+	t.Run("restore fires callback", func(t *testing.T) {
+		e := setupWithTree(t)
+
+		// Take a snapshot first.
+		e.call(t, "snapshot", map[string]any{"name": "before"})
+
+		// Mutate.
+		e.call(t, "patch", map[string]any{
+			"ops": []any{
+				map[string]any{"op": "update", "id": "header", "props": map[string]any{"text": "Changed"}},
+			},
+		})
+
+		// Now register callback and restore.
+		calls := 0
+		e.server.SetOnMutation(func() { calls++ })
+
+		e.call(t, "restore", map[string]any{"name": "before"})
+
+		if calls != 1 {
+			t.Fatalf("expected 1 mutation callback, got %d", calls)
+		}
+	})
+
+	t.Run("snapshot does not fire callback", func(t *testing.T) {
+		e := setupWithTree(t)
+		calls := 0
+		e.server.SetOnMutation(func() { calls++ })
+
+		e.call(t, "snapshot", map[string]any{"name": "test"})
+
+		if calls != 0 {
+			t.Fatalf("expected 0 mutation callbacks for snapshot, got %d", calls)
+		}
+	})
+
+	t.Run("query does not fire callback", func(t *testing.T) {
+		e := setupWithTree(t)
+		calls := 0
+		e.server.SetOnMutation(func() { calls++ })
+
+		e.call(t, "query", map[string]any{"ids": []any{"header"}})
+
+		if calls != 0 {
+			t.Fatalf("expected 0 mutation callbacks for query, got %d", calls)
+		}
+	})
+}
+
+// =============================================================================
+// Template-driven data tools: layout, set_items, append_items, remove_items
+// =============================================================================
+
+// setupWithTemplate creates a connected env and uses layout to set a tree
+// with an item_template on the "log-list" container.
+func setupWithTemplate(t *testing.T) *testEnv {
+	t.Helper()
+	e := setup(t)
+
+	r := e.call(t, "layout", map[string]any{
+		"tree": map[string]any{
+			"id":   "root",
+			"type": "container",
+			"children": []any{
+				map[string]any{"id": "header", "type": "text", "props": map[string]any{"content": "Log Viewer"}},
+				map[string]any{
+					"id":   "log-list",
+					"type": "container",
+					"props": map[string]any{
+						"item_template": map[string]any{
+							"type": "container",
+							"props": map[string]any{
+								"direction": "row",
+							},
+							"children": []any{
+								map[string]any{"type": "text", "props": map[string]any{"content": "{{level}}", "width": 8}},
+								map[string]any{"type": "text", "props": map[string]any{"content": "{{msg}}"}},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	if r.IsError {
+		t.Fatalf("setup template failed: %s", resultText(t, r))
+	}
+	return e
+}
+
+func TestLayoutTool_WholeTree(t *testing.T) {
+	e := setup(t)
+
+	result := e.call(t, "layout", map[string]any{
+		"tree": map[string]any{
+			"id":   "app",
+			"type": "container",
+			"children": []any{
+				map[string]any{"id": "header", "type": "text", "props": map[string]any{"content": "App"}},
+			},
+		},
+	})
+	if result.IsError {
+		t.Fatalf("unexpected error: %s", resultText(t, result))
+	}
+	m := resultMap(t, result)
+	if m["ok"] != true {
+		t.Errorf("expected ok:true, got %v", m)
+	}
+
+	if e.server.Tree().Root.ID != "app" {
+		t.Errorf("root ID = %q, want app", e.server.Tree().Root.ID)
+	}
+	if e.server.Tree().Find("header") == nil {
+		t.Error("header should exist")
+	}
+}
+
+func TestLayoutTool_WithItemTemplate(t *testing.T) {
+	e := setupWithTemplate(t)
+
+	// Verify the item_template is stored as a prop.
+	list := e.server.Tree().Find("log-list")
+	if list == nil {
+		t.Fatal("log-list not found")
+	}
+	tmpl, ok := list.Props["item_template"]
+	if !ok {
+		t.Fatal("item_template prop not found")
+	}
+	tmplMap, ok := tmpl.(map[string]any)
+	if !ok {
+		t.Fatalf("item_template is %T, want map[string]any", tmpl)
+	}
+	if tmplMap["type"] != "container" {
+		t.Errorf("template type = %v, want container", tmplMap["type"])
+	}
+}
+
+func TestSetItemsTool_Basic(t *testing.T) {
+	e := setupWithTemplate(t)
+
+	result := e.call(t, "set_items", map[string]any{
+		"target": "log-list",
+		"items": []any{
+			map[string]any{"level": "INFO", "msg": "server started"},
+			map[string]any{"level": "ERROR", "msg": "disk full"},
+		},
+	})
+	if result.IsError {
+		t.Fatalf("unexpected error: %s", resultText(t, result))
+	}
+	m := resultMap(t, result)
+	if m["ok"] != true {
+		t.Errorf("expected ok:true, got %v", m)
+	}
+
+	// Query to verify expanded children.
+	qResult := e.call(t, "query", map[string]any{
+		"ids": []any{"log-list"},
+	})
+	qm := resultMap(t, qResult)
+	results := qm["results"].(map[string]any)
+	listNode := results["log-list"].(map[string]any)
+	childIDs := listNode["child_ids"].([]any)
+	if len(childIDs) != 2 {
+		t.Fatalf("expected 2 children, got %d: %v", len(childIDs), childIDs)
+	}
+
+	// Verify first expanded node has correct content.
+	q2 := e.call(t, "query", map[string]any{"ids": []any{"log-list-0-0"}})
+	q2m := resultMap(t, q2)
+	r2 := q2m["results"].(map[string]any)
+	textNode := r2["log-list-0-0"].(map[string]any)
+	props := textNode["props"].(map[string]any)
+	if props["content"] != "INFO" {
+		t.Errorf("content = %v, want INFO", props["content"])
+	}
+}
+
+func TestSetItemsTool_ReplacesExisting(t *testing.T) {
+	e := setupWithTemplate(t)
+
+	// First set.
+	e.call(t, "set_items", map[string]any{
+		"target": "log-list",
+		"items":  []any{map[string]any{"level": "INFO", "msg": "first"}},
+	})
+
+	// Second set replaces.
+	result := e.call(t, "set_items", map[string]any{
+		"target": "log-list",
+		"items": []any{
+			map[string]any{"level": "ERROR", "msg": "second"},
+			map[string]any{"level": "WARN", "msg": "third"},
+		},
+	})
+	if result.IsError {
+		t.Fatalf("unexpected error: %s", resultText(t, result))
+	}
+
+	list := e.server.Tree().Find("log-list")
+	if len(list.Children) != 2 {
+		t.Fatalf("children = %d, want 2", len(list.Children))
+	}
+}
+
+func TestSetItemsTool_MissingTarget(t *testing.T) {
+	e := setupWithTemplate(t)
+	result := e.call(t, "set_items", map[string]any{
+		"target": "nonexistent",
+		"items":  []any{map[string]any{"level": "INFO", "msg": "x"}},
+	})
+	if !result.IsError {
+		t.Error("expected error for missing target")
+	}
+}
+
+func TestSetItemsTool_NoTemplate(t *testing.T) {
+	e := setupWithTemplate(t)
+	result := e.call(t, "set_items", map[string]any{
+		"target": "header",
+		"items":  []any{map[string]any{"level": "INFO", "msg": "x"}},
+	})
+	if !result.IsError {
+		t.Error("expected error for node without item_template")
+	}
+}
+
+func TestAppendItemsTool_Basic(t *testing.T) {
+	e := setupWithTemplate(t)
+
+	// Set initial items.
+	e.call(t, "set_items", map[string]any{
+		"target": "log-list",
+		"items":  []any{map[string]any{"level": "INFO", "msg": "initial"}},
+	})
+
+	// Append more.
+	result := e.call(t, "append_items", map[string]any{
+		"target": "log-list",
+		"items":  []any{map[string]any{"level": "ERROR", "msg": "appended"}},
+	})
+	if result.IsError {
+		t.Fatalf("unexpected error: %s", resultText(t, result))
+	}
+
+	list := e.server.Tree().Find("log-list")
+	if len(list.Children) != 2 {
+		t.Fatalf("children = %d, want 2", len(list.Children))
+	}
+
+	// Verify second item is the appended one.
+	q := e.call(t, "query", map[string]any{"ids": []any{"log-list-1-1"}})
+	qm := resultMap(t, q)
+	results := qm["results"].(map[string]any)
+	node := results["log-list-1-1"].(map[string]any)
+	props := node["props"].(map[string]any)
+	if props["content"] != "appended" {
+		t.Errorf("content = %v, want appended", props["content"])
+	}
+}
+
+func TestRemoveItemsTool_Basic(t *testing.T) {
+	e := setupWithTemplate(t)
+
+	e.call(t, "set_items", map[string]any{
+		"target": "log-list",
+		"items": []any{
+			map[string]any{"key": "a", "level": "INFO", "msg": "keep"},
+			map[string]any{"key": "b", "level": "ERROR", "msg": "remove"},
+			map[string]any{"key": "c", "level": "WARN", "msg": "keep"},
+		},
+	})
+
+	result := e.call(t, "remove_items", map[string]any{
+		"target": "log-list",
+		"keys":   []any{"b"},
+	})
+	if result.IsError {
+		t.Fatalf("unexpected error: %s", resultText(t, result))
+	}
+
+	list := e.server.Tree().Find("log-list")
+	if len(list.Children) != 2 {
+		t.Fatalf("children = %d, want 2", len(list.Children))
+	}
+	if e.server.Tree().Find("log-list-b") != nil {
+		t.Error("log-list-b should be removed")
+	}
+}
+
+func TestSetItems_FiresMutationCallback(t *testing.T) {
+	e := setupWithTemplate(t)
+	calls := 0
+	e.server.SetOnMutation(func() { calls++ })
+
+	e.call(t, "set_items", map[string]any{
+		"target": "log-list",
+		"items":  []any{map[string]any{"level": "INFO", "msg": "x"}},
+	})
+
+	if calls != 1 {
+		t.Fatalf("expected 1 mutation callback, got %d", calls)
+	}
+}
+
+func TestAppendItems_FiresMutationCallback(t *testing.T) {
+	e := setupWithTemplate(t)
+	e.call(t, "set_items", map[string]any{
+		"target": "log-list",
+		"items":  []any{map[string]any{"level": "INFO", "msg": "x"}},
+	})
+
+	calls := 0
+	e.server.SetOnMutation(func() { calls++ })
+
+	e.call(t, "append_items", map[string]any{
+		"target": "log-list",
+		"items":  []any{map[string]any{"level": "WARN", "msg": "y"}},
+	})
+
+	if calls != 1 {
+		t.Fatalf("expected 1 mutation callback, got %d", calls)
+	}
+}
+
+func TestRemoveItems_FiresMutationCallback(t *testing.T) {
+	e := setupWithTemplate(t)
+	e.call(t, "set_items", map[string]any{
+		"target": "log-list",
+		"items":  []any{map[string]any{"key": "x", "level": "INFO", "msg": "x"}},
+	})
+
+	calls := 0
+	e.server.SetOnMutation(func() { calls++ })
+
+	e.call(t, "remove_items", map[string]any{
+		"target": "log-list",
+		"keys":   []any{"x"},
+	})
+
+	if calls != 1 {
+		t.Fatalf("expected 1 mutation callback, got %d", calls)
+	}
+}
+
+func TestNewToolsDuringShutdown(t *testing.T) {
+	s, err := NewServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.Shutdown()
+
+	tools := []struct {
+		name string
+		args map[string]any
+	}{
+		{"layout", map[string]any{"tree": map[string]any{"id": "r", "type": "container"}}},
+		{"set_items", map[string]any{"target": "x", "items": []any{}}},
+		{"append_items", map[string]any{"target": "x", "items": []any{}}},
+		{"remove_items", map[string]any{"target": "x", "keys": []any{}}},
+	}
+
+	for _, tt := range tools {
+		t.Run(tt.name, func(t *testing.T) {
+			result := callHandlerDirect(t, s, tt.name, tt.args)
+			if !result.IsError {
+				t.Errorf("expected error during shutdown for %s", tt.name)
+			}
+			text := resultText(t, result)
+			if !strings.Contains(text, "shutting down") {
+				t.Errorf("error should mention shutting down: %s", text)
+			}
+		})
+	}
+}
+
+// --- describe_widgets tests ---
+
+func TestDescribeWidgets_All(t *testing.T) {
+	s, err := NewServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := callHandlerDirect(t, s, "describe_widgets", map[string]any{})
+	text := resultText(t, result)
+
+	// Should include known widget types.
+	for _, wtype := range []string{"list", "table", "button", "input", "container", "text"} {
+		if !strings.Contains(text, wtype) {
+			t.Errorf("catalog missing widget type %q", wtype)
+		}
+	}
+}
+
+func TestDescribeWidgets_SingleType(t *testing.T) {
+	s, err := NewServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := callHandlerDirect(t, s, "describe_widgets", map[string]any{"type": "list"})
+	text := resultText(t, result)
+
+	if !strings.Contains(text, "Navigable item list") {
+		t.Errorf("expected list description, got: %s", text)
+	}
+	if !strings.Contains(text, "select") {
+		t.Errorf("expected select event in list info, got: %s", text)
+	}
+}
+
+func TestDescribeWidgets_UnknownType(t *testing.T) {
+	s, err := NewServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := callHandlerDirect(t, s, "describe_widgets", map[string]any{"type": "nonexistent"})
+	if !result.IsError {
+		t.Error("expected error for unknown widget type")
+	}
+}
+
+// --- describe_scripting tests ---
+
+func TestDescribeScripting_ReturnsHooks(t *testing.T) {
+	s, err := NewServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := callHandlerDirect(t, s, "describe_scripting", map[string]any{})
+	text := resultText(t, result)
+
+	for _, hook := range []string{"on_mount", "on_change", "on_event", "on_focus", "on_blur", "on_key"} {
+		if !strings.Contains(text, hook) {
+			t.Errorf("missing hook %q in describe_scripting response", hook)
+		}
+	}
+}
+
+func TestDescribeScripting_ReturnsDollarAPI(t *testing.T) {
+	s, err := NewServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := callHandlerDirect(t, s, "describe_scripting", map[string]any{})
+	text := resultText(t, result)
+
+	for _, api := range []string{"$.value", "$.props", "$('id')"} {
+		if !strings.Contains(text, api) {
+			t.Errorf("missing $ API entry %q in describe_scripting response", api)
+		}
+	}
+}
+
+func TestDescribeScripting_ReturnsGlobals(t *testing.T) {
+	s, err := NewServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := callHandlerDirect(t, s, "describe_scripting", map[string]any{})
+	text := resultText(t, result)
+
+	for _, global := range []string{"emit", "state", "event", "debug"} {
+		if !strings.Contains(text, global) {
+			t.Errorf("missing global %q in describe_scripting response", global)
+		}
+	}
+}
+
+func TestDescribeScripting_ReturnsSandboxInfo(t *testing.T) {
+	s, err := NewServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := callHandlerDirect(t, s, "describe_scripting", map[string]any{})
+	text := resultText(t, result)
+
+	if !strings.Contains(text, "sandbox") {
+		t.Error("missing sandbox section in describe_scripting response")
+	}
+	if !strings.Contains(text, "require") {
+		t.Error("sandbox should mention blocked 'require'")
+	}
 }

--- a/internal/render/bridge.go
+++ b/internal/render/bridge.go
@@ -44,6 +44,11 @@ func (b *Bridge) NotifyDOMChanged() {
 	b.program.Send(DOMChangedMsg{})
 }
 
+// NotifyConnected notifies the BubbleTea program that a new MCP client connected.
+func (b *Bridge) NotifyConnected() {
+	b.program.Send(MCPConnectedMsg{})
+}
+
 // NotifyDisconnected notifies the BubbleTea program that MCP has disconnected.
 func (b *Bridge) NotifyDisconnected(err error) {
 	b.program.Send(MCPDisconnectedMsg{Err: err})

--- a/internal/render/model.go
+++ b/internal/render/model.go
@@ -1,6 +1,8 @@
 package render
 
 import (
+	"io"
+	"log/slog"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -15,6 +17,7 @@ type Model struct {
 	server  *imcp.Server
 	widgets *widget.Tree
 	focus   *FocusRing
+	logger  *slog.Logger
 
 	focusedID    string
 	width        int
@@ -28,7 +31,14 @@ func NewModel(srv *imcp.Server, registry *widget.Registry) Model {
 		server:  srv,
 		widgets: widget.NewTree(registry),
 		focus:   &FocusRing{index: make(map[string]int)},
+		logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
+}
+
+// SetLogger sets the structured logger for the render model and its widget tree.
+func (m *Model) SetLogger(l *slog.Logger) {
+	m.logger = l
+	m.widgets.SetLogger(l)
 }
 
 // Init implements tea.Model. No startup command is needed.
@@ -40,27 +50,46 @@ func (m Model) Init() tea.Cmd {
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
+		m.logger.Info("window resize", "width", msg.Width, "height", msg.Height)
 		m.width = msg.Width
 		m.height = msg.Height
 		m.syncState()
 		return m, nil
 
 	case tea.KeyMsg:
+		m.logger.Info("key", "type", msg.Type, "runes", string(msg.Runes),
+			"focused", m.focusedID, "disconnected", m.disconnected)
+		// Allow 'q' or Esc to quit when disconnected or no DOM loaded.
+		if m.disconnected || m.server.Tree() == nil {
+			if msg.Type == tea.KeyRunes && string(msg.Runes) == "q" || msg.Type == tea.KeyEsc {
+				m.server.Shutdown()
+				return m, tea.Quit
+			}
+		}
 		return m.handleKey(msg)
 
 	case DOMChangedMsg:
+		m.logger.Info("DOM changed, syncing state")
 		m.syncState()
 		// If focused node was removed, adjust focus.
 		if m.focusedID != "" && !m.focus.Contains(m.focusedID) {
 			m.focusedID = m.focus.Next("")
+			m.logger.Info("focus adjusted (removed node)", "new_focus", m.focusedID)
+		}
+		// Auto-focus first element if nothing is focused.
+		if m.focusedID == "" && len(m.focus.IDs) > 0 {
+			m.focusedID = m.focus.IDs[0]
+			m.logger.Info("auto-focus first element", "focused", m.focusedID)
 		}
 		return m, nil
 
 	case MCPDisconnectedMsg:
+		m.logger.Info("MCP disconnected", "error", msg.Err)
 		m.disconnected = true
 		return m, nil
 
 	case MCPConnectedMsg:
+		m.logger.Info("MCP connected")
 		m.disconnected = false
 		m.syncState()
 		return m, nil
@@ -76,6 +105,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // View implements tea.Model. Renders the DOM tree via the widget tree.
 func (m Model) View() string {
 	if m.width <= 0 || m.height <= 0 {
+		m.logger.Debug("view: zero dimensions", "width", m.width, "height", m.height)
 		return ""
 	}
 
@@ -85,15 +115,26 @@ func (m Model) View() string {
 
 	m.server.RLock()
 	defer m.server.RUnlock()
-	return m.widgets.Render(m.server.Tree(), m.width, m.height, m.focusedID)
+	tree := m.server.Tree()
+	m.logger.Debug("view: rendering", "root_children", len(tree.Root.Children),
+		"width", m.width, "height", m.height)
+	result := m.widgets.Render(tree, m.width, m.height, m.focusedID)
+	m.logger.Debug("view: done", "output_len", len(result))
+	return result
 }
 
 // syncState synchronizes the widget tree and focus ring with the current DOM.
 func (m *Model) syncState() {
 	m.server.RLock()
 	defer m.server.RUnlock()
-	_ = m.widgets.Sync(m.server.Tree())
-	m.focus = BuildFocusRing(m.server.Tree())
+	tree := m.server.Tree()
+	m.logger.Debug("syncState", "root_children", len(tree.Root.Children),
+		"tree_summary", tree.Summary())
+	if err := m.widgets.Sync(tree); err != nil {
+		m.logger.Error("syncState: widget sync failed", "error", err)
+	}
+	m.focus = BuildFocusRing(tree)
+	m.logger.Debug("focus ring built", "size", len(m.focus.IDs), "ids", m.focus.IDs)
 }
 
 // handleKey processes keyboard input. Acquires a read lock on the server to
@@ -111,10 +152,12 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		switch msg.Type {
 		case tea.KeyTab:
 			m.focusedID = m.focusTab(true)
+			m.logger.Info("tab focus", "new_focus", m.focusedID)
 			return m, nil
 
 		case tea.KeyShiftTab:
 			m.focusedID = m.focusTab(false)
+			m.logger.Info("shift-tab focus", "new_focus", m.focusedID)
 			return m, nil
 
 		default:

--- a/internal/render/pipeline_test.go
+++ b/internal/render/pipeline_test.go
@@ -1,0 +1,340 @@
+package render
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	imcp "github.com/joncooper/imagine-tui/internal/mcp"
+	"github.com/joncooper/imagine-tui/internal/widget"
+)
+
+// setupPipeline creates a server + model with logger, simulates WindowSizeMsg,
+// and returns the model ready for rendering. This mirrors the real BubbleTea
+// startup sequence.
+func setupPipeline(t *testing.T) (Model, *imcp.Server) {
+	t.Helper()
+	srv, err := imcp.NewServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(srv.Shutdown)
+
+	logger := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	srv.SetLogger(logger)
+
+	m := NewModel(srv, widget.DefaultRegistry())
+	m.SetLogger(logger)
+
+	// Simulate BubbleTea startup: WindowSizeMsg comes first.
+	newM, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	return newM.(Model), srv
+}
+
+// replaceTree calls the MCP replace tool and sends DOMChangedMsg to the model.
+func replaceTree(t *testing.T, m Model, srv *imcp.Server, tree map[string]any) Model {
+	t.Helper()
+	result, err := srv.CallTool(context.Background(), "replace", map[string]any{"tree": tree})
+	if err != nil {
+		t.Fatalf("replace: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("replace returned error: %v", result.Content)
+	}
+	newM, _ := m.Update(DOMChangedMsg{})
+	return newM.(Model)
+}
+
+func patchTree(t *testing.T, m Model, srv *imcp.Server, ops []map[string]any) Model {
+	t.Helper()
+	result, err := srv.CallTool(context.Background(), "patch", map[string]any{"ops": ops})
+	if err != nil {
+		t.Fatalf("patch: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("patch returned error: %v", result.Content)
+	}
+	newM, _ := m.Update(DOMChangedMsg{})
+	return newM.(Model)
+}
+
+func TestRenderPipeline(t *testing.T) {
+	t.Run("hello_world_text_prop", func(t *testing.T) {
+		m, srv := setupPipeline(t)
+		m = replaceTree(t, m, srv, map[string]any{
+			"id":   "root",
+			"type": "container",
+			"children": []map[string]any{
+				{"id": "msg", "type": "text", "props": map[string]any{"text": "Hello World"}},
+			},
+		})
+
+		view := m.View()
+		if !strings.Contains(view, "Hello World") {
+			t.Errorf("expected 'Hello World' in view, got:\n%s", view)
+		}
+	})
+
+	t.Run("hello_world_content_prop", func(t *testing.T) {
+		m, srv := setupPipeline(t)
+		m = replaceTree(t, m, srv, map[string]any{
+			"id":   "root",
+			"type": "container",
+			"children": []map[string]any{
+				{"id": "msg", "type": "text", "props": map[string]any{"content": "Hello Content"}},
+			},
+		})
+
+		view := m.View()
+		if !strings.Contains(view, "Hello Content") {
+			t.Errorf("expected 'Hello Content' in view, got:\n%s", view)
+		}
+	})
+
+	t.Run("button_renders_label", func(t *testing.T) {
+		m, srv := setupPipeline(t)
+		m = replaceTree(t, m, srv, map[string]any{
+			"id":   "root",
+			"type": "container",
+			"children": []map[string]any{
+				{"id": "btn", "type": "button", "props": map[string]any{"label": "Click Me"}},
+			},
+		})
+
+		view := m.View()
+		if !strings.Contains(view, "Click Me") {
+			t.Errorf("expected 'Click Me' in view, got:\n%s", view)
+		}
+	})
+
+	t.Run("full_layout_with_multiple_widgets", func(t *testing.T) {
+		m, srv := setupPipeline(t)
+		m = replaceTree(t, m, srv, map[string]any{
+			"id":    "root",
+			"type":  "container",
+			"props": map[string]any{"direction": "vertical"},
+			"children": []map[string]any{
+				{"id": "header", "type": "text", "props": map[string]any{"content": "Dashboard"}},
+				{
+					"id":    "body",
+					"type":  "container",
+					"props": map[string]any{"direction": "horizontal"},
+					"children": []map[string]any{
+						{"id": "btn-a", "type": "button", "props": map[string]any{"label": "Action A"}},
+						{"id": "btn-b", "type": "button", "props": map[string]any{"label": "Action B"}},
+					},
+				},
+				{"id": "search", "type": "input", "props": map[string]any{"placeholder": "Search..."}},
+				{"id": "footer", "type": "text", "props": map[string]any{"content": "Status: OK"}},
+			},
+		})
+
+		view := m.View()
+		for _, expected := range []string{"Dashboard", "Action A", "Action B", "Search...", "Status: OK"} {
+			if !strings.Contains(view, expected) {
+				t.Errorf("expected %q in view, got:\n%s", expected, view)
+			}
+		}
+	})
+
+	t.Run("replace_then_patch", func(t *testing.T) {
+		m, srv := setupPipeline(t)
+		m = replaceTree(t, m, srv, map[string]any{
+			"id":   "root",
+			"type": "container",
+			"children": []map[string]any{
+				{"id": "msg", "type": "text", "props": map[string]any{"content": "Before"}},
+			},
+		})
+
+		view := m.View()
+		if !strings.Contains(view, "Before") {
+			t.Fatalf("expected 'Before' in view, got:\n%s", view)
+		}
+
+		m = patchTree(t, m, srv, []map[string]any{
+			{"op": "update", "id": "msg", "props": map[string]any{"content": "After"}},
+		})
+
+		view = m.View()
+		if !strings.Contains(view, "After") {
+			t.Errorf("expected 'After' in view after patch, got:\n%s", view)
+		}
+		if strings.Contains(view, "Before") {
+			t.Errorf("should not contain 'Before' after patch, got:\n%s", view)
+		}
+	})
+
+	t.Run("zero_dimensions_then_resize", func(t *testing.T) {
+		srv, err := imcp.NewServer()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer srv.Shutdown()
+
+		m := NewModel(srv, widget.DefaultRegistry())
+		// Do NOT send WindowSizeMsg — dimensions are 0.
+
+		// Replace tree.
+		_, _ = srv.CallTool(context.Background(), "replace", map[string]any{
+			"tree": map[string]any{
+				"id":   "root",
+				"type": "container",
+				"children": []map[string]any{
+					{"id": "msg", "type": "text", "props": map[string]any{"content": "Waiting"}},
+				},
+			},
+		})
+		newM, _ := m.Update(DOMChangedMsg{})
+		m = newM.(Model)
+
+		// View should be empty because width=0, height=0.
+		if view := m.View(); view != "" {
+			t.Errorf("expected empty view with zero dimensions, got:\n%s", view)
+		}
+
+		// Now resize — the content should appear.
+		newM, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+		m = newM.(Model)
+
+		view := m.View()
+		if !strings.Contains(view, "Waiting") {
+			t.Errorf("expected 'Waiting' after resize, got:\n%s", view)
+		}
+	})
+
+	t.Run("unknown_widget_type_does_not_blank_siblings", func(t *testing.T) {
+		m, srv := setupPipeline(t)
+		// "progress" is a valid DOM type but not in DefaultRegistry.
+		m = replaceTree(t, m, srv, map[string]any{
+			"id":   "root",
+			"type": "container",
+			"children": []map[string]any{
+				{"id": "before", "type": "text", "props": map[string]any{"content": "Visible Before"}},
+				{"id": "unknown", "type": "progress", "props": map[string]any{"value": 50}},
+				{"id": "after", "type": "text", "props": map[string]any{"content": "Visible After"}},
+			},
+		})
+
+		view := m.View()
+		if !strings.Contains(view, "Visible Before") {
+			t.Errorf("expected 'Visible Before' despite unknown sibling, got:\n%s", view)
+		}
+		if !strings.Contains(view, "Visible After") {
+			t.Errorf("expected 'Visible After' despite unknown sibling, got:\n%s", view)
+		}
+	})
+
+	t.Run("template_expansion_with_set_items", func(t *testing.T) {
+		m, srv := setupPipeline(t)
+
+		// Use layout to define structure with item_template.
+		result, err := srv.CallTool(context.Background(), "layout", map[string]any{
+			"tree": map[string]any{
+				"id":    "root",
+				"type":  "container",
+				"props": map[string]any{"direction": "vertical"},
+				"children": []map[string]any{
+					{"id": "header", "type": "text", "props": map[string]any{"content": "Log Viewer"}},
+					{
+						"id":   "log-list",
+						"type": "container",
+						"props": map[string]any{
+							"direction": "vertical",
+							"item_template": map[string]any{
+								"type":  "container",
+								"props": map[string]any{"direction": "row"},
+								"children": []any{
+									map[string]any{"type": "text", "props": map[string]any{"content": "[{{level}}]", "width": 10}},
+									map[string]any{"type": "text", "props": map[string]any{"content": "{{msg}}"}},
+								},
+							},
+						},
+					},
+					{"id": "footer", "type": "text", "props": map[string]any{"content": "Ready"}},
+				},
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result.IsError {
+			t.Fatalf("layout error: %v", result.Content)
+		}
+		newM, _ := m.Update(DOMChangedMsg{})
+		m = newM.(Model)
+
+		// Populate with set_items.
+		result, err = srv.CallTool(context.Background(), "set_items", map[string]any{
+			"target": "log-list",
+			"items": []map[string]any{
+				{"level": "INFO", "msg": "server started"},
+				{"level": "ERROR", "msg": "disk full"},
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result.IsError {
+			t.Fatalf("set_items error: %v", result.Content)
+		}
+		newM, _ = m.Update(DOMChangedMsg{})
+		m = newM.(Model)
+
+		view := m.View()
+		for _, expected := range []string{"Log Viewer", "[INFO]", "server started", "[ERROR]", "disk full", "Ready"} {
+			if !strings.Contains(view, expected) {
+				t.Errorf("expected %q in view, got:\n%s", expected, view)
+			}
+		}
+	})
+
+	t.Run("log_viewer_demo_tree", func(t *testing.T) {
+		// Replicate the exact tree Claude Code sends in the demo.
+		m, srv := setupPipeline(t)
+		m = replaceTree(t, m, srv, map[string]any{
+			"id":    "root",
+			"type":  "container",
+			"props": map[string]any{"direction": "vertical"},
+			"children": []map[string]any{
+				{"id": "header", "type": "text", "props": map[string]any{"content": "Log Viewer", "style": "bold"}},
+				{
+					"id":    "main",
+					"type":  "container",
+					"props": map[string]any{"direction": "horizontal"},
+					"children": []map[string]any{
+						{
+							"id":    "sidebar",
+							"type":  "container",
+							"props": map[string]any{"direction": "vertical", "width": "25%", "padding": 1},
+							"children": []map[string]any{
+								{"id": "filter-label", "type": "text", "props": map[string]any{"content": "Severity Filter", "style": "bold"}},
+								{"id": "sev-error", "type": "button", "props": map[string]any{"label": "ERROR"}},
+								{"id": "sev-warn", "type": "button", "props": map[string]any{"label": "WARN"}},
+								{"id": "sev-info", "type": "button", "props": map[string]any{"label": "INFO"}},
+								{"id": "sev-debug", "type": "button", "props": map[string]any{"label": "DEBUG"}},
+								{"id": "search", "type": "input", "props": map[string]any{"placeholder": "Search logs..."}},
+							},
+						},
+						{
+							"id":    "log-view",
+							"type":  "log",
+							"props": map[string]any{"width": "fill", "sticky_bottom": true, "show_timestamps": true, "lines": []any{}},
+						},
+					},
+				},
+				{"id": "status-bar", "type": "text", "props": map[string]any{"content": "Loading...", "style": "dim"}},
+			},
+		})
+
+		view := m.View()
+		for _, expected := range []string{"Log Viewer", "Severity Filter", "ERROR", "WARN", "INFO", "DEBUG", "Search logs...", "Loading..."} {
+			if !strings.Contains(view, expected) {
+				t.Errorf("expected %q in log viewer demo view, got:\n%s", expected, view)
+			}
+		}
+	})
+}

--- a/internal/widget/catalog.go
+++ b/internal/widget/catalog.go
@@ -1,0 +1,198 @@
+package widget
+
+// Info describes a widget type for LLM discovery.
+type Info struct {
+	Type        string      `json:"type"`
+	Description string      `json:"description"`
+	Props       []PropInfo  `json:"props"`
+	Events      []EventInfo `json:"events,omitempty"`
+	Focusable   bool        `json:"focusable"`
+	Scrollable  bool        `json:"scrollable"`
+}
+
+// PropInfo describes a widget prop.
+type PropInfo struct {
+	Name        string `json:"name"`
+	Type        string `json:"type"` // "string", "int", "bool", "array", "map"
+	Description string `json:"description"`
+	Default     any    `json:"default,omitempty"`
+}
+
+// EventInfo describes an event a widget can emit.
+type EventInfo struct {
+	Type        string            `json:"type"`
+	Description string            `json:"description"`
+	DataFields  map[string]string `json:"data_fields,omitempty"`
+}
+
+// Catalog returns metadata for all available widget types.
+func Catalog() []Info {
+	return []Info{
+		{
+			Type:        "container",
+			Description: "Layout container that arranges children horizontally or vertically. Use as the structural backbone of any UI.",
+			Props: []PropInfo{
+				{Name: "direction", Type: "string", Description: "Layout direction: \"horizontal\" or \"vertical\"", Default: "vertical"},
+				{Name: "gap", Type: "int", Description: "Spacing between children in cells"},
+				{Name: "padding", Type: "int", Description: "Inner padding in cells"},
+				{Name: "border", Type: "string", Description: "Border style: \"none\", \"rounded\", \"thick\", \"double\", \"hidden\"", Default: "none"},
+				{Name: "width", Type: "string", Description: "Width: integer (fixed), \"50%\" (percent), or \"fill\" (remaining space)"},
+				{Name: "style", Type: "string", Description: "Theme token for styling"},
+				{Name: "focus_trap", Type: "bool", Description: "If true, Tab/Shift-Tab cycles only among focusable descendants"},
+				{Name: "item_template", Type: "map", Description: "Template for set_items: a node spec with {{key}} placeholders in string props"},
+			},
+			Focusable:  false,
+			Scrollable: false,
+		},
+		{
+			Type:        "text",
+			Description: "Styled text display. Supports plain text, styled segments, and word wrapping.",
+			Props: []PropInfo{
+				{Name: "content", Type: "string", Description: "Text to display (alias: \"text\")"},
+				{Name: "segments", Type: "array", Description: "Styled segments: [{\"text\": \"...\", \"style\": \"bold\"}]"},
+				{Name: "style", Type: "string", Description: "Theme token: \"bold\", \"dim\", \"danger\", \"warning\", \"success\", \"muted\""},
+				{Name: "wrap", Type: "bool", Description: "Word wrap long lines", Default: true},
+				{Name: "max_lines", Type: "int", Description: "Truncate to N lines"},
+			},
+			Focusable:  false,
+			Scrollable: false,
+		},
+		{
+			Type:        "list",
+			Description: "Navigable item list with selection, badges, and optional filtering. User navigates with up/down arrows and selects with Enter.",
+			Props: []PropInfo{
+				{Name: "items", Type: "array", Description: "Array of {id, label, badge, style} objects. Use set_items tool to populate efficiently."},
+				{Name: "selected", Type: "string", Description: "ID of initially selected item"},
+				{Name: "filterable", Type: "bool", Description: "Enable type-to-filter", Default: false},
+			},
+			Events: []EventInfo{
+				{Type: "select", Description: "User pressed Enter on an item", DataFields: map[string]string{"id": "Item ID", "label": "Item label"}},
+			},
+			Focusable:  true,
+			Scrollable: true,
+		},
+		{
+			Type:        "table",
+			Description: "Sortable data table with row selection and expandable rows. User navigates rows with up/down, selects with Enter.",
+			Props: []PropInfo{
+				{Name: "columns", Type: "array", Description: "Column definitions: [{key, label, width (int), sortable (bool)}]"},
+				{Name: "rows", Type: "array", Description: "Row data: [{col_key: value, ...}]. Use set_items tool to populate efficiently."},
+				{Name: "expandable", Type: "bool", Description: "Enable expand/collapse on Enter. Rows need a \"detail\" field.", Default: false},
+				{Name: "row_style", Type: "map", Description: "Conditional row styling: {field: \"status\", map: {\"error\": \"danger\"}}"},
+			},
+			Events: []EventInfo{
+				{Type: "select", Description: "User pressed Enter on a row (when not expandable)", DataFields: map[string]string{"index": "Row index", "row": "Full row data"}},
+				{Type: "expand", Description: "User toggled row expansion", DataFields: map[string]string{"index": "Row index", "expanded": "New expanded state"}},
+			},
+			Focusable:  true,
+			Scrollable: true,
+		},
+		{
+			Type:        "input",
+			Description: "Single-line text input with cursor, validation, and placeholder.",
+			Props: []PropInfo{
+				{Name: "value", Type: "string", Description: "Current input value"},
+				{Name: "placeholder", Type: "string", Description: "Placeholder text shown when empty"},
+				{Name: "pattern", Type: "string", Description: "Regex for validation. Border turns green/red."},
+				{Name: "style", Type: "string", Description: "Theme token"},
+			},
+			Events: []EventInfo{
+				{Type: "submit", Description: "User pressed Enter", DataFields: map[string]string{"value": "Current input value"}},
+				{Type: "change", Description: "Input value changed", DataFields: map[string]string{"value": "New value"}},
+			},
+			Focusable:  true,
+			Scrollable: false,
+		},
+		{
+			Type:        "textarea",
+			Description: "Multi-line text editor with cursor movement.",
+			Props: []PropInfo{
+				{Name: "value", Type: "string", Description: "Current text content"},
+				{Name: "placeholder", Type: "string", Description: "Placeholder text"},
+				{Name: "max_lines", Type: "int", Description: "Height constraint in lines"},
+			},
+			Events: []EventInfo{
+				{Type: "change", Description: "Text content changed", DataFields: map[string]string{"value": "New value"}},
+			},
+			Focusable:  true,
+			Scrollable: false,
+		},
+		{
+			Type:        "button",
+			Description: "Focusable action trigger. Activated with Enter or Space.",
+			Props: []PropInfo{
+				{Name: "label", Type: "string", Description: "Button text"},
+				{Name: "disabled", Type: "bool", Description: "Disable the button", Default: false},
+				{Name: "style", Type: "string", Description: "Theme token"},
+			},
+			Events: []EventInfo{
+				{Type: "click", Description: "User pressed Enter or Space on the button"},
+			},
+			Focusable:  true,
+			Scrollable: false,
+		},
+		{
+			Type:        "select",
+			Description: "Dropdown select with single or multi-select, optional filtering.",
+			Props: []PropInfo{
+				{Name: "options", Type: "array", Description: "Options: [{label, value}]"},
+				{Name: "selected", Type: "string", Description: "Selected value (string for single, array for multi)"},
+				{Name: "multi", Type: "bool", Description: "Enable multi-select", Default: false},
+				{Name: "filterable", Type: "bool", Description: "Enable type-to-filter options", Default: false},
+				{Name: "style", Type: "string", Description: "Theme token"},
+			},
+			Events: []EventInfo{
+				{Type: "change", Description: "Selection changed", DataFields: map[string]string{"selected": "Selected value(s)"}},
+			},
+			Focusable:  true,
+			Scrollable: false,
+		},
+		{
+			Type:        "log",
+			Description: "Append-only scrolling log with severity coloring and auto-scroll.",
+			Props: []PropInfo{
+				{Name: "lines", Type: "array", Description: "Log lines: [{text, level (\"error\"/\"warn\"/\"debug\"), timestamp}]"},
+				{Name: "auto_scroll", Type: "bool", Description: "Stick to bottom on new lines", Default: true},
+				{Name: "max_lines", Type: "int", Description: "Maximum retained lines", Default: 1000},
+			},
+			Focusable:  true,
+			Scrollable: true,
+		},
+		{
+			Type:        "code",
+			Description: "Code block with line numbers and line highlighting. Scrollable.",
+			Props: []PropInfo{
+				{Name: "content", Type: "string", Description: "Code text"},
+				{Name: "line_numbers", Type: "bool", Description: "Show line numbers", Default: true},
+				{Name: "start_line", Type: "int", Description: "Starting line number", Default: 1},
+				{Name: "highlight_lines", Type: "array", Description: "Lines to highlight: [3, \"5-8\", 12]"},
+			},
+			Focusable:  true,
+			Scrollable: true,
+		},
+		{
+			Type:        "diff",
+			Description: "Unified or split diff viewer with hunk navigation.",
+			Props: []PropInfo{
+				{Name: "hunks", Type: "array", Description: "Diff hunks: [{old_start, new_start, lines: [{type (\"add\"/\"remove\"/\"context\"), content, old_num, new_num}]}]"},
+				{Name: "file_name", Type: "string", Description: "File name to display"},
+				{Name: "mode", Type: "string", Description: "Display mode: \"unified\" or \"split\"", Default: "unified"},
+			},
+			Events: []EventInfo{
+				{Type: "select_line", Description: "User pressed Enter on a line", DataFields: map[string]string{"line": "Line content", "type": "Line type", "line_number": "Line number"}},
+				{Type: "hunk_navigate", Description: "User navigated to a hunk", DataFields: map[string]string{"hunk_index": "Hunk index", "direction": "next or prev"}},
+			},
+			Focusable:  true,
+			Scrollable: true,
+		},
+	}
+}
+
+// CatalogMap returns the catalog indexed by widget type for O(1) lookup.
+func CatalogMap() map[string]Info {
+	m := make(map[string]Info)
+	for _, w := range Catalog() {
+		m[w.Type] = w
+	}
+	return m
+}

--- a/internal/widget/catalog_test.go
+++ b/internal/widget/catalog_test.go
@@ -1,0 +1,88 @@
+package widget
+
+import (
+	"testing"
+
+	"github.com/joncooper/imagine-tui/internal/dom"
+)
+
+func TestCatalogCoversRegisteredTypes(t *testing.T) {
+	registry := DefaultRegistry()
+	catalog := CatalogMap()
+
+	// Every type in the registry should have a catalog entry.
+	coreTypes := []dom.NodeType{
+		dom.TypeContainer, dom.TypeText, dom.TypeInput, dom.TypeTextarea,
+		dom.TypeSelect, dom.TypeButton, dom.TypeTable, dom.TypeList,
+		dom.TypeDiff, dom.TypeLog, dom.TypeCode,
+	}
+
+	for _, nt := range coreTypes {
+		// Verify it's in the registry.
+		if _, err := registry.Create(nt); err != nil {
+			t.Errorf("type %q not in registry: %v", nt, err)
+			continue
+		}
+		// Verify it's in the catalog.
+		info, ok := catalog[string(nt)]
+		if !ok {
+			t.Errorf("type %q registered but missing from catalog", nt)
+			continue
+		}
+		if info.Description == "" {
+			t.Errorf("type %q has empty description", nt)
+		}
+		if len(info.Props) == 0 {
+			t.Errorf("type %q has no props documented", nt)
+		}
+	}
+}
+
+func TestCatalogNoDuplicateTypes(t *testing.T) {
+	seen := make(map[string]bool)
+	for _, info := range Catalog() {
+		if seen[info.Type] {
+			t.Errorf("duplicate catalog entry for type %q", info.Type)
+		}
+		seen[info.Type] = true
+	}
+}
+
+func TestCatalogPropsHaveRequiredFields(t *testing.T) {
+	for _, info := range Catalog() {
+		for _, prop := range info.Props {
+			if prop.Name == "" {
+				t.Errorf("widget %q has prop with empty name", info.Type)
+			}
+			if prop.Type == "" {
+				t.Errorf("widget %q prop %q has empty type", info.Type, prop.Name)
+			}
+			if prop.Description == "" {
+				t.Errorf("widget %q prop %q has empty description", info.Type, prop.Name)
+			}
+		}
+	}
+}
+
+func TestCatalogEventsHaveRequiredFields(t *testing.T) {
+	for _, info := range Catalog() {
+		for _, evt := range info.Events {
+			if evt.Type == "" {
+				t.Errorf("widget %q has event with empty type", info.Type)
+			}
+			if evt.Description == "" {
+				t.Errorf("widget %q event %q has empty description", info.Type, evt.Type)
+			}
+		}
+	}
+}
+
+func TestCatalogMap(t *testing.T) {
+	m := CatalogMap()
+	if _, ok := m["list"]; !ok {
+		t.Error("CatalogMap missing 'list'")
+	}
+	if _, ok := m["table"]; !ok {
+		t.Error("CatalogMap missing 'table'")
+	}
+}

--- a/internal/widget/code.go
+++ b/internal/widget/code.go
@@ -13,6 +13,7 @@ import (
 // CodeWidget implements a code block with line numbers and line highlighting.
 type CodeWidget struct {
 	scrollOffset int
+	vp           viewport
 }
 
 // Init implements Widget.
@@ -101,6 +102,12 @@ func (w *CodeWidget) View(node *dom.Node, _ []RenderedChild, ctx ViewContext) st
 		}
 
 		rendered = append(rendered, lineStr)
+	}
+
+	// Viewport clipping.
+	if ctx.Height > 0 && len(rendered) > ctx.Height {
+		vs := w.vp.slice(len(rendered), ctx.Height, w.scrollOffset)
+		rendered = rendered[vs.Start:vs.End]
 	}
 
 	return strings.Join(rendered, "\n")

--- a/internal/widget/container.go
+++ b/internal/widget/container.go
@@ -33,21 +33,25 @@ func (w *ContainerWidget) Layout(node *dom.Node, ctx ViewContext) []ChildConstra
 	available := ctx.Width - 2*padding
 	available -= borderWidth(PropString(node, "border", "none"))
 
+	availableHeight := ctx.Height - 2*padding
+	availableHeight -= borderHeight(PropString(node, "border", "none"))
+
 	if direction == "vertical" {
-		return w.layoutVertical(node, available)
+		return w.layoutVertical(node, available, availableHeight)
 	}
-	return w.layoutHorizontal(node, available, gap)
+	return w.layoutHorizontal(node, available, availableHeight, gap)
 }
 
-func (w *ContainerWidget) layoutVertical(node *dom.Node, available int) []ChildConstraint {
+func (w *ContainerWidget) layoutVertical(node *dom.Node, available, height int) []ChildConstraint {
 	constraints := make([]ChildConstraint, len(node.Children))
 	for i := range constraints {
 		constraints[i].Width = available
+		constraints[i].Height = height
 	}
 	return constraints
 }
 
-func (w *ContainerWidget) layoutHorizontal(node *dom.Node, available, gap int) []ChildConstraint {
+func (w *ContainerWidget) layoutHorizontal(node *dom.Node, available, height, gap int) []ChildConstraint {
 	n := len(node.Children)
 	totalGap := gap * (n - 1)
 	usable := available - totalGap
@@ -126,6 +130,11 @@ func (w *ContainerWidget) layoutHorizontal(node *dom.Node, available, gap int) [
 				constraints[i].Width = each
 			}
 		}
+	}
+
+	// All horizontal children share the same height.
+	for i := range constraints {
+		constraints[i].Height = height
 	}
 
 	return constraints
@@ -245,4 +254,20 @@ func borderWidth(name string) int {
 	left := len([]rune(b.Left))
 	right := len([]rune(b.Right))
 	return left + right
+}
+
+// borderHeight returns the total vertical height consumed by a border style.
+func borderHeight(name string) int {
+	b := resolveBorder(name)
+	if b == nil {
+		return 0
+	}
+	h := 0
+	if b.Top != "" {
+		h++
+	}
+	if b.Bottom != "" {
+		h++
+	}
+	return h
 }

--- a/internal/widget/diff.go
+++ b/internal/widget/diff.go
@@ -14,6 +14,7 @@ type DiffWidget struct {
 	mode         string // "unified" or "split"
 	currentHunk  int
 	scrollOffset int
+	vp           viewport
 }
 
 type diffHunk struct {
@@ -206,6 +207,12 @@ func (w *DiffWidget) View(node *dom.Node, _ []RenderedChild, ctx ViewContext) st
 			line := w.renderDiffLine(l, ctx)
 			lines = append(lines, line)
 		}
+	}
+
+	// Viewport clipping.
+	if ctx.Height > 0 && len(lines) > ctx.Height {
+		vs := w.vp.slice(len(lines), ctx.Height, w.scrollOffset)
+		lines = lines[vs.Start:vs.End]
 	}
 
 	return strings.Join(lines, "\n")

--- a/internal/widget/list.go
+++ b/internal/widget/list.go
@@ -13,6 +13,7 @@ type ListWidget struct {
 	selectedIndex int
 	filterText    string
 	filtered      []int // indices into items
+	vp            viewport
 }
 
 type listItem struct {
@@ -155,7 +156,8 @@ func (w *ListWidget) View(node *dom.Node, _ []RenderedChild, ctx ViewContext) st
 
 	w.rebuildFilter(items)
 
-	var lines []string
+	// Build all item lines.
+	allLines := make([]string, 0, len(w.filtered))
 	for _, idx := range w.filtered {
 		if idx < 0 || idx >= len(items) {
 			continue
@@ -186,8 +188,52 @@ func (w *ListWidget) View(node *dom.Node, _ []RenderedChild, ctx ViewContext) st
 			style = style.Bold(true)
 		}
 
-		lines = append(lines, style.Render(label))
+		allLines = append(allLines, style.Render(label))
 	}
 
-	return lipgloss.JoinVertical(lipgloss.Left, lines...)
+	// Viewport scrolling: find the position of selectedIndex in filtered list.
+	filteredSelIdx := 0
+	for i, idx := range w.filtered {
+		if idx == w.selectedIndex {
+			filteredSelIdx = i
+			break
+		}
+	}
+
+	// Reserve lines for scroll hints.
+	vpHeight := ctx.Height
+	if vpHeight > 0 && len(allLines) > vpHeight {
+		// We may need 1-2 lines for hints, but only if items exceed viewport.
+		hintLines := 0
+		if vpHeight > 2 {
+			hintLines = 2 // reserve space for up/down hints
+			vpHeight -= hintLines
+		}
+		vs := w.vp.slice(len(allLines), vpHeight, filteredSelIdx)
+		visible := allLines[vs.Start:vs.End]
+
+		var parts []string
+		if vs.Above > 0 {
+			hint := scrollHint(vs.Above, true)
+			if ctx.Theme != nil {
+				hint = ctx.Theme.Resolve("muted").Render(hint)
+			}
+			parts = append(parts, hint)
+		} else if hintLines > 0 {
+			parts = append(parts, "") // blank line to keep alignment
+		}
+		parts = append(parts, visible...)
+		if vs.Below > 0 {
+			hint := scrollHint(vs.Below, false)
+			if ctx.Theme != nil {
+				hint = ctx.Theme.Resolve("muted").Render(hint)
+			}
+			parts = append(parts, hint)
+		} else if hintLines > 0 {
+			parts = append(parts, "")
+		}
+		return lipgloss.JoinVertical(lipgloss.Left, parts...)
+	}
+
+	return lipgloss.JoinVertical(lipgloss.Left, allLines...)
 }

--- a/internal/widget/log.go
+++ b/internal/widget/log.go
@@ -12,6 +12,7 @@ import (
 type LogWidget struct {
 	scrollOffset int
 	stickyBottom bool
+	vp           viewport
 }
 
 type logLine struct {
@@ -98,14 +99,20 @@ func (w *LogWidget) View(node *dom.Node, _ []RenderedChild, ctx ViewContext) str
 		lines = lines[len(lines)-maxLines:]
 	}
 
-	// Sticky-bottom: show last N lines.
+	// Sticky-bottom: follow the last line.
 	if w.stickyBottom {
-		w.scrollOffset = len(lines) // will be clamped by viewport
+		w.scrollOffset = len(lines) - 1
 	}
 
 	var rendered []string
 	for _, line := range lines {
 		rendered = append(rendered, w.renderLogLine(line, ctx))
+	}
+
+	// Viewport clipping.
+	if ctx.Height > 0 && len(rendered) > ctx.Height {
+		vs := w.vp.slice(len(rendered), ctx.Height, w.scrollOffset)
+		rendered = rendered[vs.Start:vs.End]
 	}
 
 	return strings.Join(rendered, "\n")

--- a/internal/widget/props.go
+++ b/internal/widget/props.go
@@ -86,3 +86,9 @@ func PropMapSlice(node *dom.Node, key string) []map[string]any {
 	}
 	return result
 }
+
+// stringFromMap extracts a string value from a map, returning "" if missing.
+func stringFromMap(m map[string]any, key string) string {
+	v, _ := m[key].(string)
+	return v
+}

--- a/internal/widget/table.go
+++ b/internal/widget/table.go
@@ -16,6 +16,7 @@ type TableWidget struct {
 	sortColumn   string
 	sortAsc      bool
 	expandedRows map[int]bool
+	vp           viewport
 }
 
 type tableColumn struct {
@@ -169,8 +170,8 @@ func (w *TableWidget) View(node *dom.Node, _ []RenderedChild, ctx ViewContext) s
 	// Render separator.
 	sep := strings.Repeat("─", ctx.Width)
 
-	// Render rows.
-	var rowLines []string
+	// Render all rows.
+	var allRowLines []string
 	for rowIdx, row := range sortedRows {
 		rowStyle := lipgloss.NewStyle()
 		if rowStyler != nil {
@@ -185,7 +186,7 @@ func (w *TableWidget) View(node *dom.Node, _ []RenderedChild, ctx ViewContext) s
 			val := fmt.Sprintf("%v", row[col.Key])
 			cells[i] = rowStyle.Width(colWidths[i]).MaxWidth(colWidths[i]).Render(val)
 		}
-		rowLines = append(rowLines, lipgloss.JoinHorizontal(lipgloss.Top, cells...))
+		allRowLines = append(allRowLines, lipgloss.JoinHorizontal(lipgloss.Top, cells...))
 
 		// Expanded detail.
 		if w.expandedRows[rowIdx] {
@@ -195,17 +196,52 @@ func (w *TableWidget) View(node *dom.Node, _ []RenderedChild, ctx ViewContext) s
 				if ctx.Theme != nil {
 					detailStyle = mergeStyles(detailStyle, ctx.Theme.Resolve("muted"))
 				}
-				rowLines = append(rowLines, detailStyle.Render(detail))
+				allRowLines = append(allRowLines, detailStyle.Render(detail))
 			}
 		}
 	}
 
+	// Viewport scrolling for rows.
+	fixedLines := 2 // header + separator
+	vpHeight := ctx.Height - fixedLines
+	if vpHeight > 0 && len(allRowLines) > vpHeight {
+		hintLines := 0
+		if vpHeight > 2 {
+			hintLines = 2
+			vpHeight -= hintLines
+		}
+		vs := w.vp.slice(len(allRowLines), vpHeight, w.selectedRow)
+		visible := allRowLines[vs.Start:vs.End]
+
+		parts := []string{header, sep}
+		if vs.Above > 0 {
+			hint := scrollHint(vs.Above, true)
+			if ctx.Theme != nil {
+				hint = ctx.Theme.Resolve("muted").Render(hint)
+			}
+			parts = append(parts, hint)
+		} else if hintLines > 0 {
+			parts = append(parts, "")
+		}
+		parts = append(parts, visible...)
+		if vs.Below > 0 {
+			hint := scrollHint(vs.Below, false)
+			if ctx.Theme != nil {
+				hint = ctx.Theme.Resolve("muted").Render(hint)
+			}
+			parts = append(parts, hint)
+		} else if hintLines > 0 {
+			parts = append(parts, "")
+		}
+		return lipgloss.JoinVertical(lipgloss.Left, parts...)
+	}
+
 	parts := []string{header, sep}
-	parts = append(parts, rowLines...)
+	parts = append(parts, allRowLines...)
 	return lipgloss.JoinVertical(lipgloss.Left, parts...)
 }
 
-func (w *TableWidget) calcColumnWidths(cols []tableColumn, rows []map[string]any, totalWidth int) []int {
+func (w *TableWidget) calcColumnWidths(cols []tableColumn, _ []map[string]any, totalWidth int) []int {
 	n := len(cols)
 	if n == 0 {
 		return nil
@@ -238,7 +274,7 @@ func (w *TableWidget) calcColumnWidths(cols []tableColumn, rows []map[string]any
 	return widths
 }
 
-func (w *TableWidget) sortRows(rows []map[string]any, cols []tableColumn) []map[string]any {
+func (w *TableWidget) sortRows(rows []map[string]any, _ []tableColumn) []map[string]any {
 	if w.sortColumn == "" {
 		return rows
 	}
@@ -285,9 +321,4 @@ func (w *TableWidget) buildRowStyler(node *dom.Node, theme *Theme) rowStyleFunc 
 		}
 		return lipgloss.NewStyle()
 	}
-}
-
-func stringFromMap(m map[string]any, key string) string {
-	v, _ := m[key].(string)
-	return v
 }

--- a/internal/widget/text.go
+++ b/internal/widget/text.go
@@ -35,7 +35,10 @@ func (w *TextWidget) View(node *dom.Node, _ []RenderedChild, ctx ViewContext) st
 		return w.renderSegments(segments, ctx)
 	}
 
-	text := PropString(node, "text", "")
+	text := PropString(node, "content", "")
+	if text == "" {
+		text = PropString(node, "text", "")
+	}
 	styleStr := PropString(node, "style", "")
 	wrap := PropBool(node, "wrap", true)
 	maxLines := PropInt(node, "max_lines", 0)

--- a/internal/widget/viewport.go
+++ b/internal/widget/viewport.go
@@ -1,0 +1,69 @@
+package widget
+
+import "fmt"
+
+// viewport calculates which items to display in a scrollable view.
+type viewport struct {
+	offset int // first visible item index
+}
+
+// viewSlice describes the visible range of items.
+type viewSlice struct {
+	Start int // first visible item index (inclusive)
+	End   int // last visible item index (exclusive)
+	Above int // items hidden above
+	Below int // items hidden below
+}
+
+// slice returns the range of items to render given the viewport height and
+// a "follow" index (typically the selected row) that must remain visible.
+// If height <= 0 or total == 0, returns the full range.
+func (v *viewport) slice(total, height, follow int) viewSlice {
+	if height <= 0 || total == 0 {
+		return viewSlice{Start: 0, End: total}
+	}
+	if total <= height {
+		v.offset = 0
+		return viewSlice{Start: 0, End: total}
+	}
+
+	// Ensure follow index is within the visible window.
+	if follow < v.offset {
+		v.offset = follow
+	}
+	if follow >= v.offset+height {
+		v.offset = follow - height + 1
+	}
+
+	// Clamp offset.
+	if v.offset < 0 {
+		v.offset = 0
+	}
+	if v.offset > total-height {
+		v.offset = total - height
+	}
+
+	end := v.offset + height
+	if end > total {
+		end = total
+	}
+
+	return viewSlice{
+		Start: v.offset,
+		End:   end,
+		Above: v.offset,
+		Below: total - end,
+	}
+}
+
+// scrollHint returns a string like "▲ 3 more" or "▼ 12 more", or empty.
+func scrollHint(count int, up bool) string {
+	if count <= 0 {
+		return ""
+	}
+	arrow := "▼"
+	if up {
+		arrow = "▲"
+	}
+	return fmt.Sprintf("%s %d more", arrow, count)
+}

--- a/internal/widget/viewport_test.go
+++ b/internal/widget/viewport_test.go
@@ -1,0 +1,100 @@
+package widget
+
+import "testing"
+
+func TestViewport_FullyVisible(t *testing.T) {
+	v := &viewport{}
+	s := v.slice(5, 10, 0)
+	if s.Start != 0 || s.End != 5 {
+		t.Errorf("got [%d:%d], want [0:5]", s.Start, s.End)
+	}
+	if s.Above != 0 || s.Below != 0 {
+		t.Errorf("above=%d below=%d, want 0,0", s.Above, s.Below)
+	}
+}
+
+func TestViewport_ScrollDown(t *testing.T) {
+	v := &viewport{}
+	// 20 items, viewport of 5, following item 7
+	s := v.slice(20, 5, 7)
+	if s.Start > 7 || s.End <= 7 {
+		t.Errorf("follow=7 not in [%d:%d]", s.Start, s.End)
+	}
+	if s.End-s.Start != 5 {
+		t.Errorf("visible=%d, want 5", s.End-s.Start)
+	}
+	if s.Above != s.Start {
+		t.Errorf("above=%d, want %d", s.Above, s.Start)
+	}
+	if s.Below != 20-s.End {
+		t.Errorf("below=%d, want %d", s.Below, 20-s.End)
+	}
+}
+
+func TestViewport_ScrollUp(t *testing.T) {
+	v := &viewport{offset: 10}
+	// 20 items, viewport of 5, follow item 3 (above current offset)
+	s := v.slice(20, 5, 3)
+	if s.Start != 3 {
+		t.Errorf("start=%d, want 3", s.Start)
+	}
+	if s.End != 8 {
+		t.Errorf("end=%d, want 8", s.End)
+	}
+}
+
+func TestViewport_FollowAtEnd(t *testing.T) {
+	v := &viewport{}
+	s := v.slice(20, 5, 19)
+	if s.End != 20 {
+		t.Errorf("end=%d, want 20", s.End)
+	}
+	if s.Start != 15 {
+		t.Errorf("start=%d, want 15", s.Start)
+	}
+}
+
+func TestViewport_ZeroHeight(t *testing.T) {
+	v := &viewport{}
+	s := v.slice(10, 0, 0)
+	if s.Start != 0 || s.End != 10 {
+		t.Errorf("got [%d:%d], want [0:10]", s.Start, s.End)
+	}
+}
+
+func TestViewport_EmptyItems(t *testing.T) {
+	v := &viewport{}
+	s := v.slice(0, 5, 0)
+	if s.Start != 0 || s.End != 0 {
+		t.Errorf("got [%d:%d], want [0:0]", s.Start, s.End)
+	}
+}
+
+func TestViewport_Persistence(t *testing.T) {
+	v := &viewport{}
+	// Scroll to item 15
+	v.slice(20, 5, 15)
+	// Now follow item 14 — should not scroll since 14 is still visible
+	s := v.slice(20, 5, 14)
+	if s.Start > 14 || s.End <= 14 {
+		t.Errorf("item 14 not visible in [%d:%d]", s.Start, s.End)
+	}
+}
+
+func TestScrollHint(t *testing.T) {
+	tests := []struct {
+		count int
+		up    bool
+		want  string
+	}{
+		{0, true, ""},
+		{3, true, "▲ 3 more"},
+		{12, false, "▼ 12 more"},
+	}
+	for _, tt := range tests {
+		got := scrollHint(tt.count, tt.up)
+		if got != tt.want {
+			t.Errorf("scrollHint(%d, %v) = %q, want %q", tt.count, tt.up, got, tt.want)
+		}
+	}
+}

--- a/internal/widget/widgettree.go
+++ b/internal/widget/widgettree.go
@@ -1,7 +1,8 @@
 package widget
 
 import (
-	"fmt"
+	"io"
+	"log/slog"
 
 	"github.com/joncooper/imagine-tui/internal/dom"
 )
@@ -12,6 +13,7 @@ import (
 type Tree struct {
 	registry  *Registry
 	instances map[string]Widget // keyed by node ID
+	logger    *slog.Logger
 }
 
 // NewTree creates a Tree backed by the given registry.
@@ -19,38 +21,53 @@ func NewTree(registry *Registry) *Tree {
 	return &Tree{
 		registry:  registry,
 		instances: make(map[string]Widget),
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
+}
+
+// SetLogger sets the structured logger for the widget tree.
+func (wt *Tree) SetLogger(l *slog.Logger) {
+	wt.logger = l
 }
 
 // Sync walks the DOM tree and ensures every node has a widget instance.
 // New instances are created and Init'd; instances for removed nodes are deleted.
+// Unknown widget types are skipped with a warning rather than aborting the walk.
 func (wt *Tree) Sync(tree *dom.Tree) error {
 	live := make(map[string]bool)
+	created := 0
+	skipped := 0
 
-	var syncErr error
 	tree.Walk(func(n *dom.Node) bool {
 		live[n.ID] = true
 		if _, exists := wt.instances[n.ID]; !exists {
 			w, err := wt.registry.Create(n.Type)
 			if err != nil {
-				syncErr = fmt.Errorf("sync node %q: %w", n.ID, err)
-				return false
+				wt.logger.Warn("sync: skipping node with unknown type",
+					"id", n.ID, "type", n.Type, "error", err)
+				skipped++
+				return true // continue walking — don't abort on unknown types
 			}
 			w.Init(n)
 			wt.instances[n.ID] = w
+			created++
 		}
 		return true
 	})
-	if syncErr != nil {
-		return syncErr
-	}
 
 	// Remove stale instances.
+	removed := 0
 	for id := range wt.instances {
 		if !live[id] {
 			delete(wt.instances, id)
+			removed++
 		}
 	}
+
+	wt.logger.Debug("sync complete",
+		"created", created, "removed", removed, "skipped", skipped,
+		"total_instances", len(wt.instances))
+
 	return nil
 }
 
@@ -64,15 +81,19 @@ func (wt *Tree) Get(nodeID string) Widget {
 // then Render (bottom-up) composes the output.
 func (wt *Tree) Render(tree *dom.Tree, width, height int, focusedID string) string {
 	if width <= 0 {
+		wt.logger.Warn("render: zero width", "width", width)
 		return ""
 	}
 	theme := DefaultTheme()
-	return wt.renderNode(tree.Root, width, height, focusedID, theme)
+	result := wt.renderNode(tree.Root, width, height, focusedID, theme)
+	wt.logger.Debug("render complete", "output_len", len(result), "width", width, "height", height)
+	return result
 }
 
 func (wt *Tree) renderNode(node *dom.Node, width, height int, focusedID string, theme *Theme) string {
 	w := wt.instances[node.ID]
 	if w == nil {
+		wt.logger.Warn("render: no widget instance", "id", node.ID, "type", node.Type)
 		return ""
 	}
 

--- a/internal/widget/widgettree_test.go
+++ b/internal/widget/widgettree_test.go
@@ -98,7 +98,7 @@ func TestTree_Sync_PreservesExistingInstances(t *testing.T) {
 	}
 }
 
-func TestTree_Sync_UnregisteredType(t *testing.T) {
+func TestTree_Sync_UnregisteredType_SkipsAndContinues(t *testing.T) {
 	r := NewRegistry()
 	// Only register container, not text or button.
 	r.Register(dom.TypeContainer, func() Widget { return &stubWidget{} })
@@ -106,9 +106,22 @@ func TestTree_Sync_UnregisteredType(t *testing.T) {
 	wt := NewTree(r)
 	tree := makeTestTree(t)
 
+	// Sync should succeed (skipping unknown types) rather than aborting.
 	err := wt.Sync(tree)
-	if err == nil {
-		t.Fatal("expected error for unregistered node type")
+	if err != nil {
+		t.Fatalf("Sync should skip unknown types, got error: %v", err)
+	}
+
+	// Container (root) should have a widget instance.
+	if wt.Get("root") == nil {
+		t.Error("expected widget instance for root (registered type)")
+	}
+	// text and button nodes should be skipped — no widget instance.
+	if wt.Get("c1") != nil {
+		t.Error("expected nil widget for c1 (unregistered type)")
+	}
+	if wt.Get("c2") != nil {
+		t.Error("expected nil widget for c2 (unregistered type)")
 	}
 }
 


### PR DESCRIPTION
## Summary

Implemented all actionable feedback from Claude Opus 4.6's autonomous spaceship demo session. The demo exposed three core gaps in the MCP interface that are now resolved:

1. **Log widget now supports `set_items`/`append_items`/`remove_items`** via the `lines` prop, eliminating the token-wasteful pattern of resending entire arrays on every update.
2. **New `describe_scripting` MCP tool** makes scripting discoverable to clients — exposes hooks, `$` API, computed props, globals, and sandbox constraints that were previously invisible.
3. **Generic `append` patch operation** enables efficient array-valued prop updates on any widget type, not just logs.

Also includes new widget suite (catalog, viewport, code, diff, template system), demo gallery, and reorganized backlog tracking completed milestones. Timer/tick primitive deferred to future work due to infrastructure complexity.

## Test coverage

All 7 test packages pass; lint clean. Added 27 new tests covering log items operations, append patch semantics, and scripting tool output.