### PR TITLE
Fix MCP discovery for Claude Code

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "imagine_tui": {
+      "command": "go",
+      "args": ["run", "./cmd/imagine-tui", "connect", "/tmp/imagine-tui.sock"]
+    }
+  }
+}

--- a/cmd/imagine-tui/main.go
+++ b/cmd/imagine-tui/main.go
@@ -244,9 +244,14 @@ func connectCmd(args []string) error {
 	}
 	socketPath := args[0]
 
+	// Check if the socket file exists before attempting to dial.
+	if _, err := os.Stat(socketPath); os.IsNotExist(err) {
+		return fmt.Errorf("socket %s does not exist — start the server first: imagine-tui serve -socket %s", socketPath, socketPath)
+	}
+
 	conn, err := net.Dial("unix", socketPath)
 	if err != nil {
-		return fmt.Errorf("dial %s: %w", socketPath, err)
+		return fmt.Errorf("dial %s: %w (is the server running?)", socketPath, err)
 	}
 	defer func() { _ = conn.Close() }()
 

--- a/cmd/imagine-tui/serve_test.go
+++ b/cmd/imagine-tui/serve_test.go
@@ -2,12 +2,17 @@ package main
 
 import (
 	"context"
+	"encoding/json"
+	"io"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/creack/pty"
 	imcp "github.com/joncooper/imagine-tui/internal/mcp"
 	"github.com/joncooper/imagine-tui/internal/render"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -156,4 +161,299 @@ func TestUnixSocketIntegration(t *testing.T) {
 	if qResult.IsError {
 		t.Fatalf("query returned error: %v", qResult.Content)
 	}
+}
+
+// TestBridgedConnection simulates the exact flow Claude Code uses:
+// MCP client → pipes → connect bridge (io.Copy) → Unix socket → server.
+// This catches framing, buffering, or protocol issues in the bridge path.
+func TestBridgedConnection(t *testing.T) {
+	// Create server.
+	srv, err := imcp.NewServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Shutdown()
+
+	mp := &mockProgram{}
+	bridge := render.NewBridge(srv, mp)
+	srv.SetOnMutation(bridge.NotifyDOMChanged)
+
+	// Listen on a temp Unix socket.
+	socketPath := filepath.Join(t.TempDir(), "bridge.sock")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = listener.Close() }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Accept connections and wire them to the MCP server (like serveSocket does).
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer func() { _ = conn.Close() }()
+				transport := &mcp.IOTransport{Reader: conn, Writer: conn}
+				session, err := srv.MCPServer().Connect(ctx, transport, nil)
+				if err != nil {
+					return
+				}
+				bridge.NotifyConnected()
+				_ = session.Wait()
+			}()
+		}
+	}()
+
+	// Create pipes to simulate what Claude Code sees:
+	// Claude writes to clientWrite → bridge reads from bridgeStdin
+	// Bridge writes to bridgeStdout → Claude reads from clientRead
+	bridgeStdin, clientWrite := io.Pipe()
+	clientRead, bridgeStdout := io.Pipe()
+
+	// Run the connect bridge in a goroutine (simulates the connect subprocess).
+	bridgeDone := make(chan error, 1)
+	go func() {
+		conn, err := net.Dial("unix", socketPath)
+		if err != nil {
+			bridgeDone <- err
+			return
+		}
+		defer func() { _ = conn.Close() }()
+
+		errCh := make(chan error, 2)
+		go func() {
+			_, err := io.Copy(conn, bridgeStdin)
+			errCh <- err
+		}()
+		go func() {
+			_, err := io.Copy(bridgeStdout, conn)
+			errCh <- err
+		}()
+		bridgeDone <- <-errCh
+	}()
+
+	// Claude Code side: wrap the pipes as an MCP client using IOTransport.
+	clientTransport := &mcp.IOTransport{
+		Reader: clientRead,
+		Writer: clientWrite,
+	}
+	client := mcp.NewClient(&mcp.Implementation{Name: "claude-code", Version: "1.0"}, nil)
+	cs, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client connect through bridge: %v", err)
+	}
+	defer func() { _ = cs.Close() }()
+
+	// ListTools — this is what Claude Code does to discover available tools.
+	tools, err := cs.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListTools through bridge: %v", err)
+	}
+
+	if len(tools.Tools) != 12 {
+		names := make([]string, len(tools.Tools))
+		for i, tool := range tools.Tools {
+			names[i] = tool.Name
+		}
+		t.Fatalf("expected 12 tools through bridge, got %d: %v", len(tools.Tools), names)
+	}
+
+	// Verify we can also call a tool through the bridge.
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "describe_widgets",
+	})
+	if err != nil {
+		t.Fatalf("CallTool through bridge: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("describe_widgets returned error through bridge")
+	}
+
+	t.Logf("Bridge test passed: %d tools discovered, describe_widgets callable", len(tools.Tools))
+}
+
+// TestFullStackPTY is a true end-to-end test: builds the binary, starts it
+// with a real pty (so BubbleTea initializes), connects an MCP client through
+// the socket, discovers tools, and builds a UI. This exercises the exact path
+// that Claude Code uses in production.
+func TestFullStackPTY(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping full-stack pty test in short mode")
+	}
+
+	// Build the binary.
+	binPath := filepath.Join(t.TempDir(), "imagine-tui")
+	build := exec.Command("go", "build", "-o", binPath, ".")
+	build.Dir = "."
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build failed: %v\n%s", err, out)
+	}
+
+	socketPath := filepath.Join(t.TempDir(), "full-stack.sock")
+	logPath := filepath.Join(t.TempDir(), "server.log")
+
+	// Start the server with a pty so BubbleTea can initialize.
+	cmd := exec.Command(binPath, "serve", "-socket", socketPath, "-log", logPath)
+	ptmx, err := pty.Start(cmd)
+	if err != nil {
+		t.Fatalf("pty.Start: %v", err)
+	}
+	defer func() {
+		_ = cmd.Process.Signal(os.Interrupt)
+		_ = cmd.Wait()
+		_ = ptmx.Close()
+	}()
+
+	// Wait for the socket to appear (server is ready).
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(socketPath); err == nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if _, err := os.Stat(socketPath); err != nil {
+		// Dump the log for debugging.
+		logData, _ := os.ReadFile(logPath)
+		t.Fatalf("socket never appeared at %s\nserver log:\n%s", socketPath, logData)
+	}
+
+	t.Log("Server started, socket ready")
+
+	// Connect an MCP client through the socket (same as Claude Code's connect bridge).
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conn, err := net.Dial("unix", socketPath)
+	if err != nil {
+		t.Fatalf("dial socket: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	clientTransport := &mcp.IOTransport{Reader: conn, Writer: conn}
+	client := mcp.NewClient(&mcp.Implementation{Name: "claude-code-test", Version: "1.0"}, nil)
+	cs, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		logData, _ := os.ReadFile(logPath)
+		t.Fatalf("client connect: %v\nserver log:\n%s", err, logData)
+	}
+	defer func() { _ = cs.Close() }()
+
+	// 1. List tools — the critical operation that's failing in production.
+	tools, err := cs.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	toolNames := make([]string, len(tools.Tools))
+	for i, tool := range tools.Tools {
+		toolNames[i] = tool.Name
+	}
+	t.Logf("Discovered %d tools: %v", len(tools.Tools), toolNames)
+
+	if len(tools.Tools) != 12 {
+		t.Fatalf("expected 12 tools, got %d: %v", len(tools.Tools), toolNames)
+	}
+
+	// 2. Call describe_widgets.
+	dwResult, err := cs.CallTool(ctx, &mcp.CallToolParams{Name: "describe_widgets"})
+	if err != nil {
+		t.Fatalf("describe_widgets: %v", err)
+	}
+	if dwResult.IsError {
+		t.Fatalf("describe_widgets error: %v", dwResult.Content)
+	}
+	t.Log("describe_widgets: OK")
+
+	// 3. Build a UI with layout.
+	layoutResult, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "layout",
+		Arguments: map[string]any{
+			"tree": map[string]any{
+				"id":   "root",
+				"type": "container",
+				"props": map[string]any{
+					"direction": "vertical",
+					"padding":   1,
+				},
+				"children": []any{
+					map[string]any{
+						"id":    "title",
+						"type":  "text",
+						"props": map[string]any{"content": "Full Stack PTY Test", "style": "bold"},
+					},
+					map[string]any{
+						"id":   "main-list",
+						"type": "list",
+						"props": map[string]any{
+							"title": "Test Items",
+						},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("layout: %v", err)
+	}
+	if layoutResult.IsError {
+		t.Fatalf("layout error: %v", layoutResult.Content)
+	}
+	t.Log("layout: OK")
+
+	// 4. Populate the list with set_items.
+	setResult, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "set_items",
+		Arguments: map[string]any{
+			"target": "main-list",
+			"items": []any{
+				map[string]any{"id": "item-1", "label": "First item"},
+				map[string]any{"id": "item-2", "label": "Second item"},
+				map[string]any{"id": "item-3", "label": "Third item"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("set_items: %v", err)
+	}
+	if setResult.IsError {
+		t.Fatalf("set_items error: %v", setResult.Content)
+	}
+	t.Log("set_items: OK")
+
+	// 5. Query to verify DOM state.
+	qResult, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "query",
+		Arguments: map[string]any{"ids": []any{"title", "main-list"}},
+	})
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if qResult.IsError {
+		t.Fatalf("query error: %v", qResult.Content)
+	}
+
+	// Parse and verify the query response.
+	var queryResp struct {
+		Results map[string]json.RawMessage `json:"results"`
+	}
+	if len(qResult.Content) > 0 {
+		if tc, ok := qResult.Content[0].(*mcp.TextContent); ok {
+			if err := json.Unmarshal([]byte(tc.Text), &queryResp); err != nil {
+				t.Fatalf("parse query response: %v", err)
+			}
+			if _, ok := queryResp.Results["title"]; !ok {
+				t.Fatal("query missing 'title' node")
+			}
+			if _, ok := queryResp.Results["main-list"]; !ok {
+				t.Fatal("query missing 'main-list' node")
+			}
+		}
+	}
+
+	t.Log("Full stack PTY test passed: server started with BubbleTea, 12 tools discovered, UI built and verified")
 }

--- a/demo/log-viewer/.mcp.json
+++ b/demo/log-viewer/.mcp.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
-    "imagine-tui": {
-      "command": "/Users/jdc/conductor/workspaces/imagine-tui/boise/imagine-tui",
-      "args": ["connect", "/tmp/imagine-tui.sock"]
+    "imagine_tui": {
+      "command": "go",
+      "args": ["run", "../../cmd/imagine-tui", "connect", "/tmp/imagine-tui.sock"]
     }
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/clipperhouse/displaywidth v0.9.0 // indirect
 	github.com/clipperhouse/stringish v0.1.1 // indirect
 	github.com/clipperhouse/uax29/v2 v2.5.0 // indirect
+	github.com/creack/pty v1.1.24 // indirect
 	github.com/dlclark/regexp2 v1.11.4 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/go-sourcemap/sourcemap v2.1.3+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/clipperhouse/stringish v0.1.1 h1:+NSqMOr3GR6k1FdRhhnXrLfztGzuG+VuFDfa
 github.com/clipperhouse/stringish v0.1.1/go.mod h1:v/WhFtE1q0ovMta2+m+UbpZ+2/HEXNWYXQgCt4hdOzA=
 github.com/clipperhouse/uax29/v2 v2.5.0 h1:x7T0T4eTHDONxFJsL94uKNKPHrclyFI0lm7+w94cO8U=
 github.com/clipperhouse/uax29/v2 v2.5.0/go.mod h1:Wn1g7MK6OoeDT0vL+Q0SQLDz/KpfsVRgg6W7ihQeh4g=
+github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
+github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/dlclark/regexp2 v1.11.4 h1:rPYF9/LECdNymJufQKmri9gV604RvvABwgOA8un7yAo=
 github.com/dlclark/regexp2 v1.11.4/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dop251/goja v0.0.0-20260311135729-065cd970411c h1:OcLmPfx1T1RmZVHHFwWMPaZDdRf0DBMZOFMVWJa7Pdk=

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -346,6 +346,9 @@ func mergeProps(props ...map[string]any) map[string]any {
 }
 
 func inputSchema(properties map[string]any, required ...string) map[string]any {
+	if properties == nil {
+		properties = map[string]any{}
+	}
 	schema := map[string]any{
 		"type":       "object",
 		"properties": properties,


### PR DESCRIPTION
## Summary
- Add `.mcp.json` at repo root with portable `go run` command (no hardcoded binary paths)
- Rename MCP server key from `imagine-tui` to `imagine_tui` (underscore) for Claude Code tool naming compatibility
- Improve `connect` command error when socket is missing — now tells you exactly how to start the server
- Add two new integration tests: bridged connection (pipe→socket) and full-stack PTY (real binary + BubbleTea + MCP client)

## Test plan
- [x] `go test ./...` — all pass
- [x] `go vet ./...` — clean
- [x] `golangci-lint run` — 0 issues (via pre-push hook)
- [x] TestBridgedConnection: verifies MCP protocol works through io.Copy bridge
- [x] TestFullStackPTY: builds binary, starts with real pty, connects MCP client, discovers 12 tools, builds UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)