### PR TITLE
M6: render pipeline, E2E tests, and MCP refactor

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "imagine_tui": {
       "command": "/Users/jdc/conductor/workspaces/imagine-tui/casablanca-v1/imagine-tui",
-      "args": ["connect", "/tmp/imagine-tui.sock"]
+      "args": ["connect", "/tmp/imagine-tui-codex.sock"]
     }
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# AGENTS.md
+
+## Project
+Imagine TUI — an MCP server that renders interactive terminal UIs driven by Codex.
+Full spec: docs/SPEC.md
+Backlog: docs/BACKLOG.md
+
+## Development rules
+- Go 1.22+, module name: github.com/joncooper/imagine-tui
+- TDD is mandatory for internal/dom/ and internal/script/ — write the test first, confirm it fails, then implement
+- Golden file tests for widget rendering — use testdata/golden/, regenerate with GOLDEN_UPDATE=1
+- Run `go test ./...` and `golangci-lint run` before considering any task complete
+- No code without tests in dom/ or script/ packages — this is non-negotiable
+
+## Architecture layers (read SPEC.md for full detail)
+- internal/dom/ — pure data: tree, patch, snapshot, query, event queue. Zero dependencies on rendering or MCP.
+- internal/script/ — goja integration, $ API, computed props. Depends on dom/.
+- internal/widget/ — Lip Gloss renderers per widget type. Depends on dom/ + script/.
+- internal/mcp/ — MCP server, tool handlers. Depends on dom/.
+- internal/render/ — BubbleTea model, wires everything together. Depends on all.
+- cmd/imagine-tui/ — main entry point.
+
+## Style
+- Table-driven tests preferred
+- Error messages should include the node ID and operation that failed
+- No panics in library code — return errors
+- Contexts for cancellation on anything that blocks

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,13 @@
-.PHONY: build test lint golden-update clean install-hooks
+SOCKET ?= /tmp/imagine-tui.sock
+LOG ?= /tmp/imagine-tui.log
+
+.PHONY: build serve test lint golden-update clean install-hooks
 
 build:
 	go build ./cmd/imagine-tui
+
+serve: build
+	./imagine-tui serve --socket $(SOCKET) --log $(LOG)
 
 test:
 	go test ./...

--- a/cmd/imagine-tui/agent_demo_e2e_test.go
+++ b/cmd/imagine-tui/agent_demo_e2e_test.go
@@ -1,0 +1,539 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestAgentBuildsDemoAppOverBridgeAndTUIWorks(t *testing.T) {
+	socketPath, ptmx, capture, cleanup := startServePTYTerminal(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	bridge := startConnectBridgeSession(t, ctx, socketPath)
+
+	assertToolDiscovery(t, ctx, bridge.sess)
+
+	widgets := mustCallTool(t, ctx, bridge.sess, "describe_widgets", nil)
+	widgetText := toolResultText(t, widgets)
+	for _, want := range []string{"button", "input", "log"} {
+		if !strings.Contains(widgetText, want) {
+			t.Fatalf("describe_widgets missing %q: %s", want, widgetText)
+		}
+	}
+
+	scripting := mustCallTool(t, ctx, bridge.sess, "describe_scripting", nil)
+	scriptingText := toolResultText(t, scripting)
+	for _, want := range []string{"emit('agent', data)", "on_change", "computed props"} {
+		if !strings.Contains(scriptingText, want) {
+			t.Fatalf("describe_scripting missing %q: %s", want, scriptingText)
+		}
+	}
+
+	layout := mustCallTool(t, ctx, bridge.sess, "layout", map[string]any{
+		"tree": map[string]any{
+			"id":   "mission",
+			"type": "container",
+			"props": map[string]any{
+				"direction": "vertical",
+				"padding":   1,
+				"gap":       1,
+			},
+			"children": []any{
+				map[string]any{
+					"id":    "title",
+					"type":  "text",
+					"props": map[string]any{"content": "Mission Control", "style": "bold"},
+				},
+				map[string]any{
+					"id":    "status",
+					"type":  "text",
+					"props": map[string]any{"content": "Status: idle"},
+				},
+				map[string]any{
+					"id":   "command",
+					"type": "input",
+					"props": map[string]any{
+						"placeholder": "Enter command",
+					},
+					"scripts": map[string]any{
+						"on_change": "emit('local', [{op: 'update', id: 'status', props: {content: 'Status: preview ' + $.value}}]); emit('agent', {action: 'preview', value: $.value})",
+					},
+				},
+				map[string]any{
+					"id":       "count",
+					"type":     "text",
+					"computed": map[string]any{"content": "return 'Chars: ' + (($('command').value || '').length)"},
+				},
+				map[string]any{
+					"id":    "send",
+					"type":  "button",
+					"props": map[string]any{"label": "Send"},
+				},
+				map[string]any{
+					"id":   "feed",
+					"type": "log",
+					"props": map[string]any{
+						"auto_scroll": true,
+						"max_lines":   50,
+					},
+				},
+			},
+		},
+	})
+	if layout.IsError {
+		t.Fatalf("layout returned error: %v", layout.Content)
+	}
+
+	appended := mustCallTool(t, ctx, bridge.sess, "append_items", map[string]any{
+		"target": "feed",
+		"items": []any{
+			map[string]any{"text": "Mission Control online", "level": "debug"},
+			map[string]any{"text": "Awaiting operator input"},
+		},
+	})
+	if appended.IsError {
+		t.Fatalf("append_items returned error: %v", appended.Content)
+	}
+
+	waitForOutput(t, capture, "Mission Control")
+	waitForOutput(t, capture, "Status: idle")
+	waitForOutput(t, capture, "Chars: 0")
+	waitForOutput(t, capture, "Mission Control online")
+	waitForOutput(t, capture, "Enter command")
+
+	previewCh := make(chan string, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		res, err := bridge.sess.CallTool(ctx, &mcp.CallToolParams{
+			Name: "await_event",
+			Arguments: map[string]any{
+				"timeout_ms": 3000,
+				"filter":     []any{"command"},
+			},
+		})
+		if err != nil {
+			errCh <- err
+			return
+		}
+		previewCh <- toolResultText(t, res)
+	}()
+
+	if _, err := ptmx.Write([]byte("warp")); err != nil {
+		t.Fatalf("write command to PTY: %v", err)
+	}
+
+	select {
+	case err := <-errCh:
+		t.Fatalf("await_event preview failed: %v", err)
+	case text := <-previewCh:
+		for _, want := range []string{`"source":"command"`, `"action":"preview"`, `"value":"warp"`} {
+			if !strings.Contains(text, want) {
+				t.Fatalf("preview event missing %q: %s", want, text)
+			}
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for preview event")
+	}
+
+	waitForOutput(t, capture, "Status: preview warp")
+	waitForOutput(t, capture, "Chars: 4")
+	waitForOutput(t, capture, "warp")
+
+	clickCh := make(chan string, 1)
+	go func() {
+		res, err := bridge.sess.CallTool(ctx, &mcp.CallToolParams{
+			Name: "await_event",
+			Arguments: map[string]any{
+				"timeout_ms": 3000,
+				"filter":     []any{"send"},
+			},
+		})
+		if err != nil {
+			errCh <- err
+			return
+		}
+		clickCh <- toolResultText(t, res)
+	}()
+
+	if _, err := ptmx.Write([]byte("\t\r")); err != nil {
+		t.Fatalf("write tab/enter to PTY: %v", err)
+	}
+
+	select {
+	case err := <-errCh:
+		t.Fatalf("await_event click failed: %v", err)
+	case text := <-clickCh:
+		for _, want := range []string{`"source":"send"`, `"event":"click"`} {
+			if !strings.Contains(text, want) {
+				t.Fatalf("click event missing %q: %s", want, text)
+			}
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for click event")
+	}
+
+	bridge.close(t)
+	waitForOutput(t, capture, "Agent disconnected.")
+	waitForOutput(t, capture, "Waiting for reconnect...")
+
+	reconnected := startConnectBridgeSession(t, ctx, socketPath)
+	defer reconnected.close(t)
+	assertToolDiscovery(t, ctx, reconnected.sess)
+
+	query := mustCallTool(t, ctx, reconnected.sess, "query", map[string]any{
+		"ids": []any{"status", "command", "count", "send"},
+	})
+	queryText := toolResultText(t, query)
+	for _, want := range []string{"Status: preview warp", `"value":"warp"`, "Chars: 4", "Send"} {
+		if !strings.Contains(queryText, want) {
+			t.Fatalf("query after reconnect missing %q: %s", want, queryText)
+		}
+	}
+
+	patched := mustCallTool(t, ctx, reconnected.sess, "patch", map[string]any{
+		"ops": []any{
+			map[string]any{
+				"op":    "update",
+				"id":    "status",
+				"props": map[string]any{"content": "Status: launched warp"},
+			},
+			map[string]any{
+				"op":    "update",
+				"id":    "send",
+				"props": map[string]any{"label": "Sent", "disabled": true},
+			},
+		},
+	})
+	if patched.IsError {
+		t.Fatalf("patch returned error: %v", patched.Content)
+	}
+
+	appended = mustCallTool(t, ctx, reconnected.sess, "append_items", map[string]any{
+		"target": "feed",
+		"items": []any{
+			map[string]any{"text": "Command accepted: warp", "level": "warn"},
+		},
+	})
+	if appended.IsError {
+		t.Fatalf("append_items follow-up returned error: %v", appended.Content)
+	}
+
+	waitForOutput(t, capture, "Status: launched warp")
+	waitForOutput(t, capture, "Command accepted: warp")
+	waitForOutput(t, capture, "Sent")
+}
+
+func TestAgentIteratesOnMultiStepDemoScenarioOverBridge(t *testing.T) {
+	socketPath, ptmx, capture, cleanup := startServePTYTerminal(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	bridge := startConnectBridgeSession(t, ctx, socketPath)
+	defer bridge.close(t)
+
+	assertToolDiscovery(t, ctx, bridge.sess)
+
+	widgets := mustCallTool(t, ctx, bridge.sess, "describe_widgets", nil)
+	if text := toolResultText(t, widgets); !strings.Contains(text, "input") || !strings.Contains(text, "button") {
+		t.Fatalf("unexpected widget discovery: %s", text)
+	}
+	scripting := mustCallTool(t, ctx, bridge.sess, "describe_scripting", nil)
+	if text := toolResultText(t, scripting); !strings.Contains(text, "emit('agent', data)") {
+		t.Fatalf("unexpected scripting discovery: %s", text)
+	}
+
+	layout := mustCallTool(t, ctx, bridge.sess, "layout", map[string]any{
+		"tree": map[string]any{
+			"id":   "console",
+			"type": "container",
+			"props": map[string]any{
+				"direction": "vertical",
+				"padding":   1,
+				"gap":       1,
+			},
+			"children": []any{
+				map[string]any{
+					"id":    "phase",
+					"type":  "text",
+					"props": map[string]any{"content": "Phase 0: draft"},
+				},
+				map[string]any{
+					"id":   "orders",
+					"type": "input",
+					"props": map[string]any{
+						"placeholder": "Describe mission",
+					},
+					"scripts": map[string]any{
+						"on_change": "emit('local', [{op: 'update', id: 'preview', props: {content: 'Preview: ' + $.value}}, {op: 'update', id: 'action', props: {label: $.value ? 'Commit Plan' : 'Draft Plan'}}]); emit('agent', {action: 'preview', value: $.value})",
+					},
+				},
+				map[string]any{
+					"id":    "preview",
+					"type":  "text",
+					"props": map[string]any{"content": "Preview: "},
+				},
+				map[string]any{
+					"id":    "action",
+					"type":  "button",
+					"props": map[string]any{"label": "Draft Plan"},
+				},
+				map[string]any{
+					"id":   "timeline",
+					"type": "log",
+					"props": map[string]any{
+						"auto_scroll": true,
+						"max_lines":   2,
+					},
+				},
+			},
+		},
+	})
+	if layout.IsError {
+		t.Fatalf("layout returned error: %v", layout.Content)
+	}
+
+	appended := mustCallTool(t, ctx, bridge.sess, "append_items", map[string]any{
+		"target": "timeline",
+		"items": []any{
+			map[string]any{"text": "Planning console online", "level": "debug"},
+			map[string]any{"text": "Awaiting mission draft"},
+		},
+	})
+	if appended.IsError {
+		t.Fatalf("append_items returned error: %v", appended.Content)
+	}
+
+	waitForOutput(t, capture, "Phase 0: draft")
+	waitForOutput(t, capture, "Describe mission")
+	waitForOutput(t, capture, "Preview:")
+	waitForOutput(t, capture, "Planning console online")
+
+	previewCh := make(chan string, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		res, err := bridge.sess.CallTool(ctx, &mcp.CallToolParams{
+			Name: "await_event",
+			Arguments: map[string]any{
+				"timeout_ms":  3000,
+				"filter":      []any{"orders"},
+				"debounce_ms": 100,
+			},
+		})
+		if err != nil {
+			errCh <- err
+			return
+		}
+		previewCh <- toolResultText(t, res)
+	}()
+
+	if _, err := ptmx.Write([]byte("survey delta rift")); err != nil {
+		t.Fatalf("write orders to PTY: %v", err)
+	}
+
+	select {
+	case err := <-errCh:
+		t.Fatalf("await_event preview failed: %v", err)
+	case text := <-previewCh:
+		for _, want := range []string{`"source":"orders"`, `"action":"preview"`, `"value":"survey delta rift"`} {
+			if !strings.Contains(text, want) {
+				t.Fatalf("preview event missing %q: %s", want, text)
+			}
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for preview event")
+	}
+
+	waitForOutput(t, capture, "Preview: survey delta rift")
+	waitForOutput(t, capture, "Commit Plan")
+
+	patched := mustCallTool(t, ctx, bridge.sess, "patch", map[string]any{
+		"ops": []any{
+			map[string]any{
+				"op":    "update",
+				"id":    "phase",
+				"props": map[string]any{"content": "Phase 1: ready to commit"},
+			},
+		},
+	})
+	if patched.IsError {
+		t.Fatalf("patch after preview returned error: %v", patched.Content)
+	}
+	appended = mustCallTool(t, ctx, bridge.sess, "append_items", map[string]any{
+		"target": "timeline",
+		"items": []any{
+			map[string]any{"text": "Plan drafted from operator input", "level": "debug"},
+		},
+	})
+	if appended.IsError {
+		t.Fatalf("append_items after preview returned error: %v", appended.Content)
+	}
+
+	waitForOutput(t, capture, "Phase 1: ready to commit")
+	waitForOutput(t, capture, "Plan drafted from operator input")
+
+	actionCh := make(chan string, 1)
+	go func() {
+		res, err := bridge.sess.CallTool(ctx, &mcp.CallToolParams{
+			Name: "await_event",
+			Arguments: map[string]any{
+				"timeout_ms": 3000,
+				"filter":     []any{"action"},
+			},
+		})
+		if err != nil {
+			errCh <- err
+			return
+		}
+		actionCh <- toolResultText(t, res)
+	}()
+
+	if _, err := ptmx.Write([]byte("\t\r")); err != nil {
+		t.Fatalf("write tab/enter to PTY: %v", err)
+	}
+
+	select {
+	case err := <-errCh:
+		t.Fatalf("await_event action failed: %v", err)
+	case text := <-actionCh:
+		for _, want := range []string{`"source":"action"`, `"event":"click"`, `"orders":{"value":"survey delta rift"}`} {
+			if !strings.Contains(text, want) {
+				t.Fatalf("action event missing %q: %s", want, text)
+			}
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for action click")
+	}
+
+	patched = mustCallTool(t, ctx, bridge.sess, "patch", map[string]any{
+		"ops": []any{
+			map[string]any{
+				"op":    "update",
+				"id":    "phase",
+				"props": map[string]any{"content": "Phase 2: plan committed"},
+			},
+			map[string]any{
+				"op":        "insert",
+				"parent_id": "console",
+				"index":     4,
+				"node": map[string]any{
+					"id":    "launch",
+					"type":  "button",
+					"props": map[string]any{"label": "Launch Drone"},
+				},
+			},
+		},
+	})
+	if patched.IsError {
+		t.Fatalf("patch after action returned error: %v", patched.Content)
+	}
+	appended = mustCallTool(t, ctx, bridge.sess, "append_items", map[string]any{
+		"target": "timeline",
+		"items": []any{
+			map[string]any{"text": "Plan committed. Drone ready.", "level": "warn"},
+		},
+	})
+	if appended.IsError {
+		t.Fatalf("append_items after action returned error: %v", appended.Content)
+	}
+
+	waitForOutput(t, capture, "Phase 2: plan committed")
+	waitForOutput(t, capture, "Launch Drone")
+	waitForOutput(t, capture, "Plan committed. Drone ready.")
+
+	launchCh := make(chan string, 1)
+	go func() {
+		res, err := bridge.sess.CallTool(ctx, &mcp.CallToolParams{
+			Name: "await_event",
+			Arguments: map[string]any{
+				"timeout_ms": 3000,
+				"filter":     []any{"launch"},
+			},
+		})
+		if err != nil {
+			errCh <- err
+			return
+		}
+		launchCh <- toolResultText(t, res)
+	}()
+
+	if _, err := ptmx.Write([]byte("\t\r")); err != nil {
+		t.Fatalf("write tab/enter to PTY for launch: %v", err)
+	}
+
+	select {
+	case err := <-errCh:
+		t.Fatalf("await_event launch failed: %v", err)
+	case text := <-launchCh:
+		for _, want := range []string{`"source":"launch"`, `"event":"click"`} {
+			if !strings.Contains(text, want) {
+				t.Fatalf("launch event missing %q: %s", want, text)
+			}
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for launch click")
+	}
+
+	patched = mustCallTool(t, ctx, bridge.sess, "patch", map[string]any{
+		"ops": []any{
+			map[string]any{
+				"op":    "update",
+				"id":    "phase",
+				"props": map[string]any{"content": "Phase 3: drone launched"},
+			},
+			map[string]any{
+				"op":    "update",
+				"id":    "launch",
+				"props": map[string]any{"label": "Drone Deployed", "disabled": true},
+			},
+		},
+	})
+	if patched.IsError {
+		t.Fatalf("patch after launch returned error: %v", patched.Content)
+	}
+	appended = mustCallTool(t, ctx, bridge.sess, "append_items", map[string]any{
+		"target": "timeline",
+		"items": []any{
+			map[string]any{"text": "Drone launched into delta rift", "level": "warn"},
+		},
+	})
+	if appended.IsError {
+		t.Fatalf("append_items after launch returned error: %v", appended.Content)
+	}
+
+	waitForOutput(t, capture, "Phase 3: drone launched")
+	waitForOutput(t, capture, "Drone Deployed")
+	waitForOutput(t, capture, "Drone launched into delta rift")
+
+	query := mustCallTool(t, ctx, bridge.sess, "query", map[string]any{
+		"ids": []any{"phase", "preview", "launch"},
+	})
+	queryText := toolResultText(t, query)
+	for _, want := range []string{"Phase 3: drone launched", "Preview: survey delta rift", "Drone Deployed"} {
+		if !strings.Contains(queryText, want) {
+			t.Fatalf("final query missing %q: %s", want, queryText)
+		}
+	}
+}
+
+func mustCallTool(t *testing.T, ctx context.Context, sess *mcp.ClientSession, name string, args map[string]any) *mcp.CallToolResult {
+	t.Helper()
+
+	params := &mcp.CallToolParams{Name: name}
+	if args != nil {
+		params.Arguments = args
+	}
+	res, err := sess.CallTool(ctx, params)
+	if err != nil {
+		t.Fatalf("%s failed: %v", name, err)
+	}
+	return res
+}

--- a/cmd/imagine-tui/agent_demo_e2e_test.go
+++ b/cmd/imagine-tui/agent_demo_e2e_test.go
@@ -524,7 +524,7 @@ func TestAgentIteratesOnMultiStepDemoScenarioOverBridge(t *testing.T) {
 	}
 }
 
-func mustCallTool(t *testing.T, ctx context.Context, sess *mcp.ClientSession, name string, args map[string]any) *mcp.CallToolResult {
+func mustCallTool(t *testing.T, ctx context.Context, sess *mcp.ClientSession, name string, args map[string]any) *mcp.CallToolResult { //nolint:revive // ctx after t is intentional for test helpers
 	t.Helper()
 
 	params := &mcp.CallToolParams{Name: name}

--- a/cmd/imagine-tui/e2e_bridge_test.go
+++ b/cmd/imagine-tui/e2e_bridge_test.go
@@ -223,7 +223,7 @@ func TestConnectBridgeReconnectPreservesLiveUIState(t *testing.T) {
 	}
 }
 
-func startConnectBridgeSession(t *testing.T, parentCtx context.Context, socketPath string) *bridgeSession {
+func startConnectBridgeSession(t *testing.T, parentCtx context.Context, socketPath string) *bridgeSession { //nolint:revive // ctx after t is intentional for test helpers
 	t.Helper()
 
 	deadline := time.Now().Add(2 * time.Second)
@@ -256,7 +256,7 @@ type bridgeStartError struct {
 
 func (e *bridgeStartError) Error() string { return e.err.Error() }
 
-func tryStartConnectBridgeSession(t *testing.T, ctx context.Context, socketPath string) (*bridgeSession, error) {
+func tryStartConnectBridgeSession(t *testing.T, ctx context.Context, socketPath string) (*bridgeSession, error) { //nolint:revive // ctx after t is intentional for test helpers
 	t.Helper()
 
 	cmd := exec.Command(testBinaryPath(t), "connect", socketPath)
@@ -310,7 +310,7 @@ func (bs *bridgeSession) close(t *testing.T) {
 	}
 }
 
-func assertToolDiscovery(t *testing.T, ctx context.Context, sess *mcp.ClientSession) {
+func assertToolDiscovery(t *testing.T, ctx context.Context, sess *mcp.ClientSession) { //nolint:revive // ctx after t is intentional for test helpers
 	t.Helper()
 
 	tools, err := sess.ListTools(ctx, nil)

--- a/cmd/imagine-tui/e2e_bridge_test.go
+++ b/cmd/imagine-tui/e2e_bridge_test.go
@@ -1,0 +1,341 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type bridgeSession struct {
+	cmd    *exec.Cmd
+	stdin  io.WriteCloser
+	stdout io.ReadCloser
+	stderr *bytes.Buffer
+	sess   *mcp.ClientSession
+}
+
+func TestConnectBridgeReconnectListsTools(t *testing.T) {
+	socketPath, _, _, cleanup := startServePTYTerminal(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	first := startConnectBridgeSession(t, ctx, socketPath)
+	assertToolDiscovery(t, ctx, first.sess)
+	first.close(t)
+
+	second := startConnectBridgeSession(t, ctx, socketPath)
+	defer second.close(t)
+	assertToolDiscovery(t, ctx, second.sess)
+}
+
+func TestConnectBridgeServePTYEndToEndInputAndScripting(t *testing.T) {
+	socketPath, ptmx, capture, cleanup := startServePTYTerminal(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	bridge := startConnectBridgeSession(t, ctx, socketPath)
+	defer bridge.close(t)
+	assertToolDiscovery(t, ctx, bridge.sess)
+
+	result, err := bridge.sess.CallTool(ctx, &mcp.CallToolParams{
+		Name: "replace",
+		Arguments: map[string]any{
+			"tree": map[string]any{
+				"id":   "root",
+				"type": "container",
+				"props": map[string]any{
+					"direction": "vertical",
+				},
+				"children": []any{
+					map[string]any{
+						"id":    "title",
+						"type":  "text",
+						"props": map[string]any{"text": "Bridge E2E"},
+					},
+					map[string]any{
+						"id":    "status",
+						"type":  "text",
+						"props": map[string]any{"text": "Idle"},
+					},
+					map[string]any{
+						"id":    "cmd",
+						"type":  "input",
+						"props": map[string]any{"placeholder": "Type command"},
+						"scripts": map[string]any{
+							"on_change": "emit('local', [{op: 'update', id: 'status', props: {text: 'typed: ' + $.value}}]); emit('agent', {action: 'typed', value: $.value})",
+						},
+					},
+					map[string]any{
+						"id":    "run",
+						"type":  "button",
+						"props": map[string]any{"label": "Run"},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("replace returned error: %v", result.Content)
+	}
+
+	waitForOutput(t, capture, "Bridge E2E")
+	waitForOutput(t, capture, "Type command")
+
+	typedCh := make(chan string, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		res, callErr := bridge.sess.CallTool(ctx, &mcp.CallToolParams{
+			Name: "await_event",
+			Arguments: map[string]any{
+				"timeout_ms": 2000,
+				"filter":     []any{"cmd"},
+			},
+		})
+		if callErr != nil {
+			errCh <- callErr
+			return
+		}
+		typedCh <- toolResultText(t, res)
+	}()
+
+	if _, err := ptmx.Write([]byte("go")); err != nil {
+		t.Fatalf("write input to PTY: %v", err)
+	}
+
+	select {
+	case err := <-errCh:
+		t.Fatalf("await_event failed: %v", err)
+	case text := <-typedCh:
+		if !strings.Contains(text, "\"action\":\"typed\"") {
+			t.Fatalf("expected typed action, got: %s", text)
+		}
+		if !strings.Contains(text, "\"source\":\"cmd\"") {
+			t.Fatalf("expected cmd source, got: %s", text)
+		}
+		if !strings.Contains(text, "\"value\":\"go\"") {
+			t.Fatalf("expected input value go, got: %s", text)
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for typed event")
+	}
+
+	waitForOutput(t, capture, "typed: go")
+
+	clickCh := make(chan string, 1)
+	go func() {
+		res, callErr := bridge.sess.CallTool(ctx, &mcp.CallToolParams{
+			Name: "await_event",
+			Arguments: map[string]any{
+				"timeout_ms": 2000,
+				"filter":     []any{"run"},
+			},
+		})
+		if callErr != nil {
+			errCh <- callErr
+			return
+		}
+		clickCh <- toolResultText(t, res)
+	}()
+
+	if _, err := ptmx.Write([]byte("\t\r")); err != nil {
+		t.Fatalf("write tab/enter to PTY: %v", err)
+	}
+
+	select {
+	case err := <-errCh:
+		t.Fatalf("await_event click failed: %v", err)
+	case text := <-clickCh:
+		if !strings.Contains(text, "\"event\":\"click\"") {
+			t.Fatalf("expected click event, got: %s", text)
+		}
+		if !strings.Contains(text, "\"source\":\"run\"") {
+			t.Fatalf("expected run source, got: %s", text)
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for click event")
+	}
+}
+
+func TestConnectBridgeReconnectPreservesLiveUIState(t *testing.T) {
+	socketPath, _, capture, cleanup := startServePTYTerminal(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	first := startConnectBridgeSession(t, ctx, socketPath)
+	result, err := first.sess.CallTool(ctx, &mcp.CallToolParams{
+		Name: "replace",
+		Arguments: map[string]any{
+			"tree": map[string]any{
+				"id":   "root",
+				"type": "container",
+				"children": []any{
+					map[string]any{
+						"id":    "header",
+						"type":  "text",
+						"props": map[string]any{"text": "Persisted UI"},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("replace returned error: %v", result.Content)
+	}
+	waitForOutput(t, capture, "Persisted UI")
+	first.close(t)
+
+	second := startConnectBridgeSession(t, ctx, socketPath)
+	defer second.close(t)
+	assertToolDiscovery(t, ctx, second.sess)
+
+	query, err := second.sess.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "query",
+		Arguments: map[string]any{"ids": []any{"header"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if query.IsError {
+		t.Fatalf("query returned error after reconnect: %v", query.Content)
+	}
+
+	text := toolResultText(t, query)
+	if !strings.Contains(text, "Persisted UI") {
+		t.Fatalf("expected persisted UI after reconnect, got: %s", text)
+	}
+}
+
+func startConnectBridgeSession(t *testing.T, parentCtx context.Context, socketPath string) *bridgeSession {
+	t.Helper()
+
+	deadline := time.Now().Add(2 * time.Second)
+	var lastErr error
+	var lastStderr string
+	for time.Now().Before(deadline) {
+		attemptCtx, cancel := context.WithTimeout(parentCtx, 750*time.Millisecond)
+		bs, err := tryStartConnectBridgeSession(t, attemptCtx, socketPath)
+		cancel()
+		if err == nil {
+			return bs
+		}
+		lastErr = err
+		if bridgeErr, ok := err.(*bridgeStartError); ok {
+			lastStderr = bridgeErr.stderr
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if lastStderr != "" {
+		t.Fatalf("failed to start connect bridge session: %v\nstderr:\n%s", lastErr, lastStderr)
+	}
+	t.Fatalf("failed to start connect bridge session: %v", lastErr)
+	return nil
+}
+
+type bridgeStartError struct {
+	err    error
+	stderr string
+}
+
+func (e *bridgeStartError) Error() string { return e.err.Error() }
+
+func tryStartConnectBridgeSession(t *testing.T, ctx context.Context, socketPath string) (*bridgeSession, error) {
+	t.Helper()
+
+	cmd := exec.Command(testBinaryPath(t), "connect", socketPath)
+	cmd.Dir = "."
+	stderr := &bytes.Buffer{}
+	cmd.Stderr = stderr
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		_ = stdin.Close()
+		return nil, err
+	}
+	if err := cmd.Start(); err != nil {
+		_ = stdin.Close()
+		_ = stdout.Close()
+		return nil, err
+	}
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "bridge-client", Version: "0.0.1"}, nil)
+	sess, err := client.Connect(ctx, &mcp.IOTransport{Reader: stdout, Writer: stdin}, nil)
+	if err != nil {
+		_ = stdin.Close()
+		_ = stdout.Close()
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+		return nil, &bridgeStartError{err: err, stderr: stderr.String()}
+	}
+
+	return &bridgeSession{cmd: cmd, stdin: stdin, stdout: stdout, stderr: stderr, sess: sess}, nil
+}
+
+func (bs *bridgeSession) close(t *testing.T) {
+	t.Helper()
+
+	if bs.sess != nil {
+		_ = bs.sess.Close()
+	}
+	if bs.stdin != nil {
+		_ = bs.stdin.Close()
+	}
+	if bs.stdout != nil {
+		_ = bs.stdout.Close()
+	}
+	if bs.cmd != nil && bs.cmd.Process != nil {
+		_ = bs.cmd.Process.Kill()
+		_, _ = bs.cmd.Process.Wait()
+	}
+}
+
+func assertToolDiscovery(t *testing.T, ctx context.Context, sess *mcp.ClientSession) {
+	t.Helper()
+
+	tools, err := sess.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListTools failed: %v", err)
+	}
+	if len(tools.Tools) < 12 {
+		names := make([]string, len(tools.Tools))
+		for i, tool := range tools.Tools {
+			names[i] = tool.Name
+		}
+		t.Fatalf("expected at least 12 tools, got %d: %v", len(tools.Tools), names)
+	}
+	for _, want := range []string{"describe_widgets", "describe_scripting", "replace", "layout", "set_items", "await_event", "patch"} {
+		if !hasToolNamed(tools.Tools, want) {
+			t.Fatalf("missing tool %q from discovery", want)
+		}
+	}
+}
+
+func hasToolNamed(tools []*mcp.Tool, want string) bool {
+	for _, tool := range tools {
+		if tool.Name == want {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/imagine-tui/main.go
+++ b/cmd/imagine-tui/main.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -120,13 +121,14 @@ func serveStdio(srv *imcp.Server, logger *slog.Logger) error {
 	mcpErrCh := make(chan error, 1)
 	go func() {
 		logger.Info("MCP server starting on stdio")
+		bridge.NotifyConnected(1)
 		err := srv.MCPServer().Run(ctx, &mcp.StdioTransport{})
 		mcpErrCh <- err
 		logger.Info("MCP stdio session ended", "error", err)
 		if err != nil && err != io.EOF {
-			bridge.NotifyDisconnected(err)
+			bridge.NotifyDisconnected(1, err)
 		} else {
-			bridge.NotifyDisconnected(nil)
+			bridge.NotifyDisconnected(1, nil)
 		}
 	}()
 
@@ -190,6 +192,7 @@ func serveSocket(srv *imcp.Server, socketPath string, logger *slog.Logger) error
 	}()
 
 	// Accept MCP connections on the Unix socket.
+	owners := &ownerGate{}
 	go func() {
 		for {
 			conn, err := listener.Accept()
@@ -198,7 +201,7 @@ func serveSocket(srv *imcp.Server, socketPath string, logger *slog.Logger) error
 				return // listener closed
 			}
 			logger.Info("client connected", "remote", conn.RemoteAddr())
-			go handleConnection(ctx, srv, bridge, conn, logger)
+			go handleConnection(ctx, srv, bridge, owners, conn, logger)
 		}
 	}()
 
@@ -212,8 +215,41 @@ func serveSocket(srv *imcp.Server, socketPath string, logger *slog.Logger) error
 	return err
 }
 
-func handleConnection(ctx context.Context, srv *imcp.Server, bridge *render.Bridge, conn net.Conn, logger *slog.Logger) {
+type ownerGate struct {
+	mu     sync.Mutex
+	next   uint64
+	active uint64
+}
+
+func (g *ownerGate) TryClaim() (uint64, bool) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.active != 0 {
+		return 0, false
+	}
+	g.next++
+	g.active = g.next
+	return g.active, true
+}
+
+func (g *ownerGate) Release(id uint64) bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if id == 0 || g.active != id {
+		return false
+	}
+	g.active = 0
+	return true
+}
+
+func handleConnection(ctx context.Context, srv *imcp.Server, bridge *render.Bridge, owners *ownerGate, conn net.Conn, logger *slog.Logger) {
 	defer func() { _ = conn.Close() }()
+
+	sessionID, ok := owners.TryClaim()
+	if !ok {
+		logger.Warn("owner rejected", "remote", conn.RemoteAddr())
+		return
+	}
 
 	transport := &mcp.IOTransport{
 		Reader: conn,
@@ -222,17 +258,22 @@ func handleConnection(ctx context.Context, srv *imcp.Server, bridge *render.Brid
 
 	session, err := srv.MCPServer().Connect(ctx, transport, nil)
 	if err != nil {
+		owners.Release(sessionID)
 		logger.Error("MCP connect failed", "error", err)
 		return
 	}
 
-	bridge.NotifyConnected()
-	logger.Info("MCP session established")
+	bridge.NotifyConnected(sessionID)
+	if sessionID == 1 {
+		logger.Info("owner attached", "session_id", sessionID)
+	} else {
+		logger.Info("owner reattached", "session_id", sessionID)
+	}
 
 	err = session.Wait()
-	logger.Info("MCP session ended", "error", err)
-	if err != nil && err != io.EOF && err != context.Canceled {
-		bridge.NotifyDisconnected(err)
+	logger.Info("MCP session ended", "session_id", sessionID, "error", err)
+	if owners.Release(sessionID) {
+		bridge.NotifyDisconnected(sessionID, err)
 	}
 }
 

--- a/cmd/imagine-tui/ownership_test.go
+++ b/cmd/imagine-tui/ownership_test.go
@@ -326,12 +326,12 @@ func TestServePTYEndToEndRendersAndAcceptsInput(t *testing.T) {
 	}
 }
 
-func startServePTY(t *testing.T) (string, *threadSafeBuffer, func()) {
+func startServePTY(t *testing.T) (string, *threadSafeBuffer, func()) { //nolint:gocritic // unnamed results are clearer here
 	socketPath, _, capture, cleanup := startServePTYTerminal(t)
 	return socketPath, capture, cleanup
 }
 
-func startServePTYTerminal(t *testing.T) (string, *os.File, *threadSafeBuffer, func()) {
+func startServePTYTerminal(t *testing.T) (string, *os.File, *threadSafeBuffer, func()) { //nolint:gocritic // unnamed results are clearer here
 	t.Helper()
 
 	tmpFile, err := os.CreateTemp("/tmp", "imtu-*.sock")

--- a/cmd/imagine-tui/ownership_test.go
+++ b/cmd/imagine-tui/ownership_test.go
@@ -1,0 +1,431 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/creack/pty"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type threadSafeBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+var builtTestBinary struct {
+	once sync.Once
+	path string
+	err  error
+}
+
+func (b *threadSafeBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *threadSafeBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+func TestOwnerGateSingleActive(t *testing.T) {
+	var gate ownerGate
+
+	first, ok := gate.TryClaim()
+	if !ok || first != 1 {
+		t.Fatalf("first claim = (%d, %v), want (1, true)", first, ok)
+	}
+	if _, ok := gate.TryClaim(); ok {
+		t.Fatal("second claim should be rejected while owner is active")
+	}
+	if !gate.Release(first) {
+		t.Fatal("expected active owner release to succeed")
+	}
+
+	second, ok := gate.TryClaim()
+	if !ok || second != 2 {
+		t.Fatalf("second claim after release = (%d, %v), want (2, true)", second, ok)
+	}
+}
+
+func TestOwnerGateRejectsStaleRelease(t *testing.T) {
+	var gate ownerGate
+
+	first, ok := gate.TryClaim()
+	if !ok {
+		t.Fatal("expected first claim to succeed")
+	}
+	if gate.Release(first + 1) {
+		t.Fatal("stale release should fail")
+	}
+	if !gate.Release(first) {
+		t.Fatal("current owner release should succeed")
+	}
+}
+
+func TestShellOwnedSessionReconnectsWithoutBlankingThePTY(t *testing.T) {
+	socketPath, capture, cleanup := startServePTY(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conn1, err := net.Dial("unix", socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client1 := mcp.NewClient(&mcp.Implementation{Name: "client-1", Version: "0.0.1"}, nil)
+	session1, err := client1.Connect(ctx, &mcp.IOTransport{Reader: conn1, Writer: conn1}, nil)
+	if err != nil {
+		_ = conn1.Close()
+		t.Fatal(err)
+	}
+
+	result, err := session1.CallTool(ctx, &mcp.CallToolParams{
+		Name: "replace",
+		Arguments: map[string]any{
+			"tree": map[string]any{
+				"id":   "root",
+				"type": "container",
+				"children": []any{
+					map[string]any{
+						"id":    "header",
+						"type":  "text",
+						"props": map[string]any{"text": "Hello PTY"},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("replace returned error: %v", result.Content)
+	}
+
+	waitForOutput(t, capture, "Hello PTY")
+	_ = session1.Close()
+	_ = conn1.Close()
+	waitForOutput(t, capture, "Agent disconnected.")
+	waitForOutput(t, capture, "reconnect...")
+
+	conn2, err := net.Dial("unix", socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = conn2.Close() }()
+	client2 := mcp.NewClient(&mcp.Implementation{Name: "client-2", Version: "0.0.1"}, nil)
+	session2, err := client2.Connect(ctx, &mcp.IOTransport{Reader: conn2, Writer: conn2}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = session2.Close() }()
+
+	query, err := session2.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "query",
+		Arguments: map[string]any{"ids": []any{"header"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if query.IsError {
+		t.Fatalf("query returned error after reconnect: %v", query.Content)
+	}
+}
+
+func TestActiveOwnerRejectsSecondSocketClient(t *testing.T) {
+	socketPath, _, cleanup := startServePTY(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conn1, err := net.Dial("unix", socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = conn1.Close() }()
+	client1 := mcp.NewClient(&mcp.Implementation{Name: "client-1", Version: "0.0.1"}, nil)
+	session1, err := client1.Connect(ctx, &mcp.IOTransport{Reader: conn1, Writer: conn1}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = session1.Close() }()
+
+	secondConn, err := net.Dial("unix", socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = secondConn.Close() }()
+
+	if err := secondConn.SetReadDeadline(time.Now().Add(500 * time.Millisecond)); err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 1)
+	if _, err := secondConn.Read(buf); err == nil {
+		t.Fatal("expected rejected second client connection to close")
+	}
+
+	tools, err := session1.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("active owner should remain usable: %v", err)
+	}
+	if len(tools.Tools) == 0 {
+		t.Fatal("expected tools from active owner session")
+	}
+}
+
+func TestServePTYEndToEndRendersAndAcceptsInput(t *testing.T) {
+	socketPath, ptmx, capture, cleanup := startServePTYTerminal(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conn, err := net.Dial("unix", socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "e2e-client", Version: "0.0.1"}, nil)
+	session, err := client.Connect(ctx, &mcp.IOTransport{Reader: conn, Writer: conn}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = session.Close() }()
+
+	waitForOutput(t, capture, "\x1b[?1049h")
+
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name: "replace",
+		Arguments: map[string]any{
+			"tree": map[string]any{
+				"id":   "root",
+				"type": "container",
+				"props": map[string]any{
+					"direction": "vertical",
+				},
+				"children": []any{
+					map[string]any{
+						"id":    "title",
+						"type":  "text",
+						"props": map[string]any{"text": "TTY E2E"},
+					},
+					map[string]any{
+						"id":    "cmd",
+						"type":  "input",
+						"props": map[string]any{"placeholder": "Type command"},
+					},
+					map[string]any{
+						"id":    "run",
+						"type":  "button",
+						"props": map[string]any{"label": "Run"},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("replace returned error: %v", result.Content)
+	}
+
+	waitForOutput(t, capture, "TTY E2E")
+	waitForOutput(t, capture, "Type command")
+
+	changeCh := make(chan string, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		res, callErr := session.CallTool(ctx, &mcp.CallToolParams{
+			Name: "await_event",
+			Arguments: map[string]any{
+				"filter":      []any{"cmd"},
+				"timeout_ms":  2000,
+				"debounce_ms": 50,
+			},
+		})
+		if callErr != nil {
+			errCh <- callErr
+			return
+		}
+		changeCh <- toolResultText(t, res)
+	}()
+
+	if _, err := ptmx.Write([]byte("go")); err != nil {
+		t.Fatalf("write input to PTY: %v", err)
+	}
+
+	select {
+	case callErr := <-errCh:
+		t.Fatalf("await_event for input change failed: %v", callErr)
+	case text := <-changeCh:
+		if !strings.Contains(text, "\"event\":\"change\"") {
+			t.Fatalf("expected change event, got: %s", text)
+		}
+		if !strings.Contains(text, "\"source\":\"cmd\"") {
+			t.Fatalf("expected cmd source, got: %s", text)
+		}
+		if !strings.Contains(text, "\"value\":\"go\"") {
+			t.Fatalf("expected input value go, got: %s", text)
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for input change event")
+	}
+
+	waitForOutput(t, capture, "go")
+
+	clickCh := make(chan string, 1)
+	go func() {
+		res, callErr := session.CallTool(ctx, &mcp.CallToolParams{
+			Name: "await_event",
+			Arguments: map[string]any{
+				"filter":     []any{"run"},
+				"timeout_ms": 2000,
+			},
+		})
+		if callErr != nil {
+			errCh <- callErr
+			return
+		}
+		clickCh <- toolResultText(t, res)
+	}()
+
+	if _, err := ptmx.Write([]byte("\t\r")); err != nil {
+		t.Fatalf("write tab/enter to PTY: %v", err)
+	}
+
+	select {
+	case callErr := <-errCh:
+		t.Fatalf("await_event for button click failed: %v", callErr)
+	case text := <-clickCh:
+		if !strings.Contains(text, "\"event\":\"click\"") {
+			t.Fatalf("expected click event, got: %s", text)
+		}
+		if !strings.Contains(text, "\"source\":\"run\"") {
+			t.Fatalf("expected run source, got: %s", text)
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for button click event")
+	}
+}
+
+func startServePTY(t *testing.T) (string, *threadSafeBuffer, func()) {
+	socketPath, _, capture, cleanup := startServePTYTerminal(t)
+	return socketPath, capture, cleanup
+}
+
+func startServePTYTerminal(t *testing.T) (string, *os.File, *threadSafeBuffer, func()) {
+	t.Helper()
+
+	tmpFile, err := os.CreateTemp("/tmp", "imtu-*.sock")
+	if err != nil {
+		t.Fatalf("create temp socket path: %v", err)
+	}
+	socketPath := tmpFile.Name()
+	_ = tmpFile.Close()
+	_ = os.Remove(socketPath)
+
+	cmd := exec.Command(testBinaryPath(t), "serve", "-socket", socketPath)
+	cmd.Dir = "."
+
+	ptmx, err := pty.StartWithSize(cmd, &pty.Winsize{Rows: 24, Cols: 80})
+	if err != nil {
+		t.Fatalf("pty start: %v", err)
+	}
+
+	capture := &threadSafeBuffer{}
+	done := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(capture, ptmx)
+		close(done)
+	}()
+
+	waitForOutput(t, capture, "Listening on")
+
+	cleanup := func() {
+		_ = ptmx.Close()
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+			_, _ = cmd.Process.Wait()
+		}
+		<-done
+		_ = os.Remove(socketPath)
+	}
+
+	return socketPath, ptmx, capture, cleanup
+}
+
+func testBinaryPath(t *testing.T) string {
+	t.Helper()
+
+	builtTestBinary.once.Do(func() {
+		tmpFile, err := os.CreateTemp("/tmp", "imagine-tui-test-*")
+		if err != nil {
+			builtTestBinary.err = fmt.Errorf("create temp binary path: %w", err)
+			return
+		}
+		builtTestBinary.path = tmpFile.Name()
+		_ = tmpFile.Close()
+		_ = os.Remove(builtTestBinary.path)
+
+		cmd := exec.Command("go", "build", "-o", builtTestBinary.path, ".")
+		cmd.Dir = "."
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			builtTestBinary.err = fmt.Errorf("build test binary: %w: %s", err, strings.TrimSpace(string(output)))
+		}
+	})
+
+	if builtTestBinary.err != nil {
+		t.Fatal(builtTestBinary.err)
+	}
+	return builtTestBinary.path
+}
+
+func waitForOutput(t *testing.T, capture *threadSafeBuffer, needle string) {
+	t.Helper()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if strings.Contains(capture.String(), needle) {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %q in PTY output:\n%s", needle, capture.String())
+}
+
+func toolResultText(t *testing.T, r *mcp.CallToolResult) string {
+	t.Helper()
+	if len(r.Content) == 0 {
+		t.Fatal("result has no content")
+	}
+	data, err := json.Marshal(r.Content[0])
+	if err != nil {
+		t.Fatalf("marshal content: %v", err)
+	}
+	var wire struct {
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(data, &wire); err != nil {
+		t.Fatalf("unmarshal content: %v", err)
+	}
+	return wire.Text
+}

--- a/cmd/imagine-tui/serve_test.go
+++ b/cmd/imagine-tui/serve_test.go
@@ -304,9 +304,11 @@ func TestFullStackPTY(t *testing.T) {
 		t.Fatalf("pty.Start: %v", err)
 	}
 	defer func() {
-		_ = cmd.Process.Signal(os.Interrupt)
-		_ = cmd.Wait()
 		_ = ptmx.Close()
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+			_, _ = cmd.Process.Wait()
+		}
 	}()
 
 	// Wait for the socket to appear (server is ready).

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -137,6 +137,44 @@ Design doc: [docs/demos/log-detective.md](demos/log-detective.md)
 
 Items not tied to a milestone. Will be scheduled as needed.
 
+### Container viewport & overflow scrolling
+- Add `height` / `max_height` props to containers (fixed int or percentage)
+- Add `overflow` prop: `"scroll"` wraps children in a bubbletea viewport
+- Without this, tall content pushes the entire screen down instead of scrolling within its panel
+- Discovered during live demo: log/narrative panels overflow their containers
+- **Implementation**: wrap container rendering in `viewport.Model` when `overflow: "scroll"` and height is constrained
+- **TDD**: golden file tests for constrained containers, overflow clipping
+
+### Flex layout & layout managers
+- Flex grow/shrink (one panel fills remaining space after siblings)
+- Min/max width constraints on containers
+- Wrapping grids (flow children into rows when they overflow)
+- Current `width: "50%"` and `direction` cover basics but can't express elastic layouts
+- **Implementation**: lipgloss `Place` + custom flex algorithm, or adopt a layout library
+- **TDD**: layout calculation unit tests for grow/shrink/wrap scenarios
+
+### Script runtime: state in computed props & cross-node state
+- Make `state` readable from computed props (currently only `$` props are accessible)
+- Add `$('other-node').state` for cross-node state sharing
+- Eliminates the hidden-input workaround for shared reactive state
+- Key enabler for client-side-heavy UIs (games, dashboards with complex local logic)
+- **TDD**: computed prop reads state, cross-node state access, reactivity triggers
+
+### Script runtime: timers (setTimeout/setInterval)
+- Sandboxed short-duration timers for animations and timed events
+- Combat damage flash, countdown timers, progress animations
+- Must integrate with bubbletea's `tea.Tick` command pattern
+- Safety: max duration cap, max concurrent timers, auto-cancel on node removal
+- **TDD**: timer fires, timer cancels on remove, max limits enforced
+
+### BubbleTea ecosystem widget integration
+- Progress bar widget (from `bubbles/progress`)
+- Spinner widget (from `bubbles/spinner`)
+- Markdown/glamour widget (from `glamour`)
+- Sparkline widget (needed for M7 living dashboard)
+- Each maps to a new widget type in the registry
+- **TDD**: golden file tests per new widget type
+
 ### TSX fragment runtime
 - Implement the JSX transform in the goja layer
 - Component registry: `<ListItem>`, `<Text>`, `<Container>` → DOM node specs
@@ -154,6 +192,13 @@ Items not tied to a milestone. Will be scheduled as needed.
 - MCP reconnection after disconnect
 - DOM consistency checks (orphaned nodes, dangling references)
 - **TDD**: every error path, every recovery mechanism
+
+### Dedicated agent-launched Ghostty sessions
+- Launch imagine-tui in a dedicated Ghostty window/tab for a single agent session
+- Treat the Ghostty process/window as the ownership and lifetime boundary
+- Closing the window terminates the session and prevents further control
+- Design socket ownership, launcher lifecycle, cleanup semantics, and any required session registry
+- Defer until shell-run single-owner reconnect and live scripting are stable
 
 ### Documentation & packaging
 - README with architecture overview, quickstart, demo walkthroughs

--- a/docs/SCRIPT_RUNTIME.md
+++ b/docs/SCRIPT_RUNTIME.md
@@ -12,7 +12,7 @@ The script package currently contains only `doc.go` and a trivial goja import te
 
 **$ is both an object and a function.** Use goja's `ProxyTrapConfig` wrapping a callable function: `Get`/`Set` traps delegate to a `nodeProxy` for property access (`$.value`), while the `Apply` trap handles `$('id')` lookups. Cross-node proxies returned by `$('id')` are plain `DynamicObject`s.
 
-**Scripts mutate the DOM directly.** Write operations on `$` proxies call `node.SetProp()` and mark the node dirty. `emit('local', ops)` calls `tree.Patch()` synchronously. `emit('claude', data)` calls `events.Enqueue()`. After each script execution, dirty nodes trigger computed prop re-evaluation via the dependency graph.
+**Scripts mutate the DOM directly.** Write operations on `$` proxies call `node.SetProp()` and mark the node dirty. `emit('local', ops)` calls `tree.Patch()` synchronously. `emit('agent', data)` calls `events.Enqueue()`. After each script execution, dirty nodes trigger computed prop re-evaluation via the dependency graph.
 
 ## File Layout
 
@@ -20,7 +20,7 @@ The script package currently contains only `doc.go` and a trivial goja import te
 internal/script/
 ├── runtime.go     — Runtime struct, New(), initSandbox(), execScript(), timeout
 ├── proxy.go       — nodeProxy (DynamicObject), setupContext() with ProxyTrapConfig
-├── emit.go        — makeEmitFn(): local -> tree.Patch(), claude -> events.Enqueue()
+├── emit.go        — makeEmitFn(): local -> tree.Patch(), agent -> events.Enqueue()
 ├── state.go       — per-node state map[string]*goja.Object, getOrCreate/remove
 ├── hooks.go       — ExecHook(), NotifyMount/Remove/Change, public API
 ├── computed.go    — DepGraph (forward+reverse maps), EvalComputed(), propagateChanges(), cycle detection
@@ -118,11 +118,11 @@ func (rt *Runtime) NotifyChange(nodeID string, newValue any) error
 
 - [x] `makeEmitFn(sourceNodeID)` returns a Go function exposed to JS
 - [x] `emit('local', [...ops])`: marshal JS value → JSON → `dom.ParsePatchOps()` → `tree.Patch()`
-- [x] `emit('claude', {data})`: build `dom.Event{Type: "script", Source: nodeID, Data: data}` → `events.Enqueue()`
+- [x] `emit('agent', {data})`: build `dom.Event{Type: "script", Source: nodeID, Data: data}` → `events.Enqueue()`
 - [x] Invalid target → JS TypeError via `panic(rt.vm.NewTypeError(...))`
 - [x] Test: `emit('local', [{op:'update', id:'x', props:{text:'hi'}}])` applies patch to tree
 - [x] Test: `emit('local', invalidOps)` throws
-- [x] Test: `emit('claude', {action:'submit'})` enqueues event with correct source/data
+- [x] Test: `emit('agent', {action:'submit'})` enqueues event with correct source/data
 - [x] Test: `emit('bad', {})` throws TypeError
 
 ### Step 6: M3-6 — Script Lifecycle Hooks

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -163,7 +163,7 @@ Handles: new screen construction, complex decisions, ambiguous user intent, data
 Each node's event hooks declare their tier:
 - `"local"` — handled entirely by BubbleTea (focus, scroll, cursor)
 - Script function body — runs in goja instantly
-- `"claude"` — queued for the next `await_event` call, which routes to Claude Code
+- `"agent"` — queued for the next `await_event` call, which routes to Claude Code
 
 ### Event coalescing
 Rapid user actions (toggling multiple filter checkboxes, repeated keypresses) can generate a burst of Claude-routed events. The `debounce_ms` parameter on `await_event` coalesces these into a single return, preventing wasteful round-trips. The server holds events for the debounce window and returns the most recent, with a `coalesced_count` field so Claude knows it missed intermediate states and can query if needed.
@@ -194,7 +194,7 @@ $('id').visible — show/hide
 $('id').rows   — table-specific accessors
 
 emit('local', patch)   — apply DOM patch instantly
-emit('claude', data)   — queue event for Claude Code
+emit('agent', data)   — queue event for Claude Code
 
 state                  — persistent script-local store
 state.x ??= 0         — survives across script invocations
@@ -225,7 +225,7 @@ $('results').render(
 ```
 
 ### Sandboxing
-goja is configured with no I/O primitives: no `require`, no `fetch`, no filesystem, no timers (the runtime provides `on_tick` as a hook instead). Scripts can read/write the DOM, keep local state, and `emit`. The only door to the outside world is `emit('claude', ...)`.
+goja is configured with no I/O primitives: no `require`, no `fetch`, no filesystem, no timers (the runtime provides `on_tick` as a hook instead). Scripts can read/write the DOM, keep local state, and `emit`. The only door to the outside world is `emit('agent', ...)`.
 
 ## Widget library
 

--- a/docs/demos/log-viewer.md
+++ b/docs/demos/log-viewer.md
@@ -74,7 +74,7 @@ container (id: "root", direction: vertical)
 6. **Search input change** → `on_change` script filters entries matching the search term, updates log widget locally.
 
 ### Claude-routed interactions (1-3s round trip)
-7. **Select a log entry** (if supported) → `emit('claude', { line, severity, message })` → Claude explains the error, reads source files for context
+7. **Select a log entry** (if supported) → `emit('agent', { line, severity, message })` → Claude explains the error, reads source files for context
 8. Claude calls `patch` to insert an explanation panel below the log
 9. Back to `await_event`
 

--- a/docs/widget/DESIGN.md
+++ b/docs/widget/DESIGN.md
@@ -816,8 +816,8 @@ When a widget's `Update()` produces an `Event`, the M5 runtime routes it:
 2. If script exists → run it (M3 responsibility). The widget's default behavior
    for this event is **skipped**.
 3. If no script → the widget's default behavior was already applied during
-   `Update()`. No further action unless the event is `"claude"` routed.
-4. If the script body is literally `"claude"` → enqueue in EventQueue.
+   `Update()`. No further action unless the event is `"agent"` routed.
+4. If the script body is literally `"agent"` → enqueue in EventQueue.
 
 This means widgets implement their default behaviors directly in `Update()`.
 Scripts override by replacing the hook. The runtime layer (M5) checks for

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/clipperhouse/displaywidth v0.9.0 // indirect
 	github.com/clipperhouse/stringish v0.1.1 // indirect
 	github.com/clipperhouse/uax29/v2 v2.5.0 // indirect
+	github.com/creack/pty v1.1.24 // indirect
 	github.com/dlclark/regexp2 v1.11.4 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/go-sourcemap/sourcemap v2.1.3+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -80,3 +80,5 @@ golang.org/x/tools v0.41.0 h1:a9b8iMweWG+S0OBnlU36rzLp20z1Rp10w+IY2czHTQc=
 golang.org/x/tools v0.41.0/go.mod h1:XSY6eDqxVNiYgezAVqqCeihT4j1U2CCsqvH3WhQpnlg=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
+github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
+github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -105,7 +105,7 @@ func NewServer() (*Server, error) {
 	}
 
 	s.srv = mcp.NewServer(&mcp.Implementation{
-		Name:    "imagine-tui",
+		Name:    "imagine_tui",
 		Version: "0.1.0",
 	}, &mcp.ServerOptions{
 		Instructions: serverInstructions,
@@ -256,10 +256,9 @@ func patchTool() *mcp.Tool {
 	return &mcp.Tool{
 		Name:        "patch",
 		Description: "Apply an ordered list of atomic operations to the TUI DOM tree. Supported ops: update, insert, remove, move, append.",
-		InputSchema: inputSchema(
-			prop("ops", "array", "Ordered list of patch operations (update, insert, remove, move, append). Append op: {op: \"append\", id: \"node-id\", prop: \"lines\", values: [...]}"),
-			"ops",
-		),
+		InputSchema: schema(map[string]JSONSchema{
+			"ops": {Type: "array", Description: "Ordered list of patch operations (update, insert, remove, move, append). Append op: {op: \"append\", id: \"node-id\", prop: \"lines\", values: [...]}"},
+		}, "ops"),
 	}
 }
 
@@ -267,13 +266,11 @@ func replaceTool() *mcp.Tool {
 	return &mcp.Tool{
 		Name:        "replace",
 		Description: "Replace an entire subtree or the whole tree",
-		InputSchema: inputSchema(
-			mergeProps(
-				prop("target_id", "string", "ID of the node whose children will be replaced. If omitted, replaces the entire tree."),
-				prop("tree", "object", "Full tree spec for whole-tree replacement (when target_id is omitted)"),
-				prop("children", "array", "Array of node specs to replace the target's children"),
-			),
-		),
+		InputSchema: schema(map[string]JSONSchema{
+			"target_id": {Type: "string", Description: "ID of the node whose children will be replaced. If omitted, replaces the entire tree."},
+			"tree":      {Type: "object", Description: "Full tree spec for whole-tree replacement (when target_id is omitted)"},
+			"children":  {Type: "array", Description: "Array of node specs to replace the target's children"},
+		}),
 	}
 }
 
@@ -281,13 +278,11 @@ func awaitEventTool() *mcp.Tool {
 	return &mcp.Tool{
 		Name:        "await_event",
 		Description: "Long-poll: block until a Claude-routed event fires, then return it with context",
-		InputSchema: inputSchema(
-			mergeProps(
-				prop("timeout_ms", "number", "Return timeout:true after this many milliseconds if no event fires"),
-				prop("filter", "array", "Array of node IDs to listen to. Events from other nodes are held."),
-				prop("debounce_ms", "number", "Coalesce rapid events within this window (ms)"),
-			),
-		),
+		InputSchema: schema(map[string]JSONSchema{
+			"timeout_ms":  {Type: "number", Description: "Return timeout:true after this many milliseconds if no event fires"},
+			"filter":      {Type: "array", Description: "Array of node IDs to listen to. Events from other nodes are held."},
+			"debounce_ms": {Type: "number", Description: "Coalesce rapid events within this window (ms)"},
+		}),
 	}
 }
 
@@ -295,10 +290,9 @@ func snapshotTool() *mcp.Tool {
 	return &mcp.Tool{
 		Name:        "snapshot",
 		Description: "Save the current DOM state under a name",
-		InputSchema: inputSchema(
-			prop("name", "string", "Name for this snapshot"),
-			"name",
-		),
+		InputSchema: schema(map[string]JSONSchema{
+			"name": {Type: "string", Description: "Name for this snapshot"},
+		}, "name"),
 	}
 }
 
@@ -306,10 +300,9 @@ func restoreTool() *mcp.Tool {
 	return &mcp.Tool{
 		Name:        "restore",
 		Description: "Restore the DOM to a previously saved snapshot",
-		InputSchema: inputSchema(
-			prop("name", "string", "Name of the snapshot to restore"),
-			"name",
-		),
+		InputSchema: schema(map[string]JSONSchema{
+			"name": {Type: "string", Description: "Name of the snapshot to restore"},
+		}, "name"),
 	}
 }
 
@@ -317,43 +310,61 @@ func queryTool() *mcp.Tool {
 	return &mcp.Tool{
 		Name:        "query",
 		Description: "Read back current state of specific nodes",
-		InputSchema: inputSchema(
-			prop("ids", "array", "Array of node IDs to query"),
-			"ids",
-		),
+		InputSchema: schema(map[string]JSONSchema{
+			"ids": {Type: "array", Description: "Array of node IDs to query"},
+		}, "ids"),
 	}
 }
 
-// --- Schema helpers ---
+// --- Schema types ---
 
-func prop(name, typ, desc string) map[string]any {
-	return map[string]any{
-		name: map[string]any{
-			"type":        typ,
-			"description": desc,
-		},
+// JSONSchema is a minimal JSON Schema object for MCP tool input schemas.
+type JSONSchema struct {
+	Type        string                `json:"type"`
+	Description string                `json:"description,omitempty"`
+	Properties  map[string]JSONSchema `json:"properties,omitempty"`
+	Required    []string              `json:"required,omitempty"`
+}
+
+// schema builds a JSONSchema with the given properties and required fields.
+// An empty properties map is always allocated so it serializes as {} not null.
+func schema(props map[string]JSONSchema, required ...string) JSONSchema {
+	if props == nil {
+		props = map[string]JSONSchema{}
+	}
+	return JSONSchema{
+		Type:       "object",
+		Properties: props,
+		Required:   required,
 	}
 }
 
-func mergeProps(props ...map[string]any) map[string]any {
-	merged := make(map[string]any)
-	for _, p := range props {
-		for k, v := range p {
-			merged[k] = v
-		}
-	}
-	return merged
+// --- Tool response types ---
+
+type okResult struct {
+	OK bool `json:"ok"`
 }
 
-func inputSchema(properties map[string]any, required ...string) map[string]any {
-	schema := map[string]any{
-		"type":       "object",
-		"properties": properties,
-	}
-	if len(required) > 0 {
-		schema["required"] = required
-	}
-	return schema
+type okCountResult struct {
+	OK        bool `json:"ok"`
+	NodeCount int  `json:"node_count,omitempty"`
+	Count     int  `json:"count,omitempty"`
+	Removed   int  `json:"removed,omitempty"`
+}
+
+type okNameResult struct {
+	OK       bool   `json:"ok"`
+	Name     string `json:"name,omitempty"`
+	Restored string `json:"restored,omitempty"`
+}
+
+type timeoutResult struct {
+	Timeout bool `json:"timeout"`
+}
+
+type queryResult struct {
+	Results map[string]*dom.QueryResult `json:"results"`
+	Errors  []string                    `json:"errors,omitempty"`
 }
 
 // --- Tool handlers ---
@@ -389,7 +400,7 @@ func (s *Server) handlePatch(ctx context.Context, req *mcp.CallToolRequest) (*mc
 
 	s.logger.Info("patch: success")
 	s.notifyMutation()
-	return jsonResult(map[string]any{"ok": true})
+	return jsonResult(okResult{OK: true})
 }
 
 func (s *Server) handleReplace(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -429,7 +440,7 @@ func (s *Server) handleReplace(ctx context.Context, req *mcp.CallToolRequest) (*
 		s.mu.Unlock()
 		s.logger.Info("replace: success", "node_count", nodeCount, "tree_summary", summary)
 		s.notifyMutation()
-		return jsonResult(map[string]any{"ok": true, "node_count": nodeCount})
+		return jsonResult(okCountResult{OK: true, NodeCount: nodeCount})
 	}
 
 	// Subtree replacement.
@@ -449,7 +460,7 @@ func (s *Server) handleReplace(ctx context.Context, req *mcp.CallToolRequest) (*
 	s.mu.Unlock()
 
 	s.notifyMutation()
-	return jsonResult(map[string]any{"ok": true})
+	return jsonResult(okResult{OK: true})
 }
 
 func (s *Server) handleAwaitEvent(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -479,7 +490,7 @@ func (s *Server) handleAwaitEvent(ctx context.Context, req *mcp.CallToolRequest)
 	if err != nil {
 		// Check if this was a timeout.
 		if deqCtx.Err() != nil && input.TimeoutMs > 0 {
-			return jsonResult(map[string]any{"timeout": true})
+			return jsonResult(timeoutResult{Timeout: true})
 		}
 		return errResult(fmt.Sprintf("await_event: %v", err)), nil
 	}
@@ -514,7 +525,7 @@ func (s *Server) handleSnapshot(ctx context.Context, req *mcp.CallToolRequest) (
 		return errResult(err.Error()), nil
 	}
 
-	return jsonResult(map[string]any{"ok": true, "name": input.Name})
+	return jsonResult(okNameResult{OK: true, Name: input.Name})
 }
 
 func (s *Server) handleRestore(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -539,7 +550,7 @@ func (s *Server) handleRestore(ctx context.Context, req *mcp.CallToolRequest) (*
 	}
 
 	s.notifyMutation()
-	return jsonResult(map[string]any{"ok": true, "restored": input.Name})
+	return jsonResult(okNameResult{OK: true, Restored: input.Name})
 }
 
 func (s *Server) handleQuery(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -561,16 +572,13 @@ func (s *Server) handleQuery(ctx context.Context, req *mcp.CallToolRequest) (*mc
 	results, errs := s.tree.Query(input.IDs)
 	s.mu.Unlock()
 
-	resp := map[string]any{
-		"results": results,
-	}
+	resp := queryResult{Results: results}
 	if len(errs) > 0 {
-		errStrs := make([]string, len(errs))
+		resp.Errors = make([]string, len(errs))
 		for i, e := range errs {
-			errStrs[i] = e.Error()
+			resp.Errors[i] = e.Error()
 		}
-		resp["errors"] = errStrs
-		s.logger.Warn("query: some IDs not found", "errors", errStrs)
+		s.logger.Warn("query: some IDs not found", "errors", resp.Errors)
 	}
 
 	return jsonResult(resp)
@@ -582,10 +590,9 @@ func layoutTool() *mcp.Tool {
 	return &mcp.Tool{
 		Name:        "layout",
 		Description: "Define or replace the UI structure. Container nodes may include an item_template prop for use with set_items/append_items. Idempotent.",
-		InputSchema: inputSchema(
-			prop("tree", "object", "Full tree spec. Container nodes may include an item_template prop with {{key}} placeholders."),
-			"tree",
-		),
+		InputSchema: schema(map[string]JSONSchema{
+			"tree": {Type: "object", Description: "Full tree spec. Container nodes may include an item_template prop with {{key}} placeholders."},
+		}, "tree"),
 	}
 }
 
@@ -593,13 +600,10 @@ func setItemsTool() *mcp.Tool {
 	return &mcp.Tool{
 		Name:        "set_items",
 		Description: "Populate a list, table, log, or templated container with data. For list nodes: items are {id, label, badge, style}. For table nodes: items are row objects. For log nodes: items are {text, level, timestamp}. For containers with item_template: items are expanded through the template. Replaces all existing items.",
-		InputSchema: inputSchema(
-			mergeProps(
-				prop("target", "string", "ID of the list node or container with item_template"),
-				prop("items", "array", "Array of data objects. For lists: {id, label, badge, style}. For templates: keys map to {{key}} placeholders."),
-			),
-			"target", "items",
-		),
+		InputSchema: schema(map[string]JSONSchema{
+			"target": {Type: "string", Description: "ID of the list node or container with item_template"},
+			"items":  {Type: "array", Description: "Array of data objects. For lists: {id, label, badge, style}. For templates: keys map to {{key}} placeholders."},
+		}, "target", "items"),
 	}
 }
 
@@ -607,13 +611,10 @@ func appendItemsTool() *mcp.Tool {
 	return &mcp.Tool{
 		Name:        "append_items",
 		Description: "Append data items to a list, table, log, or templated container without replacing existing items.",
-		InputSchema: inputSchema(
-			mergeProps(
-				prop("target", "string", "ID of the list node or container with item_template"),
-				prop("items", "array", "Array of data objects to append"),
-			),
-			"target", "items",
-		),
+		InputSchema: schema(map[string]JSONSchema{
+			"target": {Type: "string", Description: "ID of the list node or container with item_template"},
+			"items":  {Type: "array", Description: "Array of data objects to append"},
+		}, "target", "items"),
 	}
 }
 
@@ -621,13 +622,10 @@ func removeItemsTool() *mcp.Tool {
 	return &mcp.Tool{
 		Name:        "remove_items",
 		Description: "Remove items from a list, table, log, or templated container. For list/table/log nodes: keys match item id fields. For containers: keys compute child IDs as {target}-{key}.",
-		InputSchema: inputSchema(
-			mergeProps(
-				prop("target", "string", "ID of the list node or container"),
-				prop("keys", "array", "Array of item keys to remove"),
-			),
-			"target", "keys",
-		),
+		InputSchema: schema(map[string]JSONSchema{
+			"target": {Type: "string", Description: "ID of the list node or container"},
+			"keys":   {Type: "array", Description: "Array of item keys to remove"},
+		}, "target", "keys"),
 	}
 }
 
@@ -635,11 +633,9 @@ func describeWidgetsTool() *mcp.Tool {
 	return &mcp.Tool{
 		Name:        "describe_widgets",
 		Description: "List available widget types with their props, events, and capabilities. Call this before building a UI to discover what widgets you can use. Optionally filter by type.",
-		InputSchema: inputSchema(
-			mergeProps(
-				prop("type", "string", "Optional: filter to a specific widget type (e.g. \"list\", \"table\")"),
-			),
-		),
+		InputSchema: schema(map[string]JSONSchema{
+			"type": {Type: "string", Description: "Optional: filter to a specific widget type (e.g. \"list\", \"table\")"},
+		}),
 	}
 }
 
@@ -669,7 +665,7 @@ func describeScriptingTool() *mcp.Tool {
 	return &mcp.Tool{
 		Name:        "describe_scripting",
 		Description: "Describe the reactive scripting system: lifecycle hooks, the $ node API, computed props, emit, and state. Call this to learn how to add client-side logic to widgets.",
-		InputSchema: inputSchema(nil),
+		InputSchema: schema(nil),
 	}
 }
 
@@ -716,6 +712,7 @@ func scriptingCatalog() *scriptingInfo {
 		Hooks: []hookInfo{
 			{Name: "on_mount", Description: "Runs once when the node enters the DOM"},
 			{Name: "on_change", Description: "Runs when the node's value prop changes (inputs, selects)"},
+			{Name: "on_submit", Description: "Runs when the user presses Enter on an input. Script runs first for instant feedback, then the event is still forwarded to the agent."},
 			{Name: "on_event", Description: "Runs when a child node emits an event (bubbles up)"},
 			{Name: "on_focus", Description: "Runs when the node receives focus"},
 			{Name: "on_blur", Description: "Runs when the node loses focus"},
@@ -736,7 +733,7 @@ func scriptingCatalog() *scriptingInfo {
 		},
 		Globals: []apiEntry{
 			{Name: "emit('local', patchOps)", Description: "Apply a DOM patch synchronously from within the script (no MCP round-trip)"},
-			{Name: "emit('claude', data)", Description: "Queue an event for the MCP client (delivered via await_event)"},
+			{Name: "emit('agent', data)", Description: "Queue an event for the MCP client (delivered via await_event)"},
 			{Name: "state", Description: "Per-node persistent JavaScript object — survives across hook invocations"},
 			{Name: "event", Description: "The hook payload object (e.g., key info for on_key, value for on_change). Only defined during hook execution."},
 			{Name: "debug(...args)", Description: "Log to the server's debug output (not visible in TUI)"},
@@ -756,7 +753,7 @@ func scriptingCatalog() *scriptingInfo {
 			},
 			{
 				Title: "on_change hook: filter a list when input changes",
-				Code:  `{"scripts": {"on_change": "emit('claude', {action: 'filter', query: $.value})"}}`,
+				Code:  `{"scripts": {"on_change": "emit('agent', {action: 'filter', query: $.value})"}}`,
 			},
 		},
 	}
@@ -799,7 +796,7 @@ func (s *Server) handleLayout(ctx context.Context, req *mcp.CallToolRequest) (*m
 
 	s.logger.Info("layout: success", "node_count", nodeCount)
 	s.notifyMutation()
-	return jsonResult(map[string]any{"ok": true, "node_count": nodeCount})
+	return jsonResult(okCountResult{OK: true, NodeCount: nodeCount})
 }
 
 func (s *Server) handleSetItems(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -835,7 +832,7 @@ func (s *Server) handleSetItems(ctx context.Context, req *mcp.CallToolRequest) (
 
 	s.logger.Info("set_items: success")
 	s.notifyMutation()
-	return jsonResult(map[string]any{"ok": true, "count": len(items)})
+	return jsonResult(okCountResult{OK: true, Count: len(items)})
 }
 
 func (s *Server) handleAppendItems(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -871,7 +868,7 @@ func (s *Server) handleAppendItems(ctx context.Context, req *mcp.CallToolRequest
 
 	s.logger.Info("append_items: success")
 	s.notifyMutation()
-	return jsonResult(map[string]any{"ok": true, "count": len(items)})
+	return jsonResult(okCountResult{OK: true, Count: len(items)})
 }
 
 func (s *Server) handleRemoveItems(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -907,7 +904,7 @@ func (s *Server) handleRemoveItems(ctx context.Context, req *mcp.CallToolRequest
 
 	s.logger.Info("remove_items: success")
 	s.notifyMutation()
-	return jsonResult(map[string]any{"ok": true, "removed": len(keys)})
+	return jsonResult(okCountResult{OK: true, Removed: len(keys)})
 }
 
 // --- Helpers ---

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -135,6 +135,18 @@ func (s *Server) Snapshots() *dom.SnapshotStore {
 	return s.snaps
 }
 
+// Lock acquires an exclusive write lock on the server's state. Use this when
+// the BubbleTea goroutine needs to write to the DOM (e.g. widget SetProp) while
+// MCP mutations may be running concurrently.
+func (s *Server) Lock() {
+	s.mu.Lock()
+}
+
+// Unlock releases the write lock.
+func (s *Server) Unlock() {
+	s.mu.Unlock()
+}
+
 // RLock acquires a read lock on the server's state. Use this when reading
 // the DOM tree from a goroutine that may run concurrently with MCP mutations.
 func (s *Server) RLock() {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -1792,3 +1792,308 @@ func TestDescribeScripting_ReturnsSandboxInfo(t *testing.T) {
 		t.Error("sandbox should mention blocked 'require'")
 	}
 }
+
+// =============================================================================
+// Error handling and dynamic path coverage
+// =============================================================================
+
+func TestReplaceToolInvalidTreeJSON(t *testing.T) {
+	e := setup(t)
+	r := e.call(t, "replace", map[string]any{
+		"tree": "not-an-object",
+	})
+	if !r.IsError {
+		t.Error("expected error for invalid tree JSON")
+	}
+}
+
+func TestReplaceToolInvalidChildrenJSON(t *testing.T) {
+	e := setupWithTree(t)
+	r := e.call(t, "replace", map[string]any{
+		"target_id": "main",
+		"children":  "not-an-array",
+	})
+	if !r.IsError {
+		t.Error("expected error for invalid children JSON")
+	}
+}
+
+func TestReplaceToolReplaceTreeFailure(t *testing.T) {
+	e := setup(t)
+	// Duplicate IDs should cause ReplaceTree to fail.
+	r := e.call(t, "replace", map[string]any{
+		"tree": map[string]any{
+			"id":   "root",
+			"type": "container",
+			"children": []any{
+				map[string]any{"id": "dup", "type": "text"},
+				map[string]any{"id": "dup", "type": "text"},
+			},
+		},
+	})
+	if !r.IsError {
+		t.Error("expected error for duplicate IDs in tree")
+	}
+}
+
+func TestLayoutTool_MissingTree(t *testing.T) {
+	e := setup(t)
+	r := e.call(t, "layout", map[string]any{})
+	if !r.IsError {
+		t.Error("expected error for missing tree")
+	}
+}
+
+func TestLayoutTool_InvalidTreeJSON(t *testing.T) {
+	e := setup(t)
+	r := e.call(t, "layout", map[string]any{
+		"tree": "not-an-object",
+	})
+	if !r.IsError {
+		t.Error("expected error for invalid tree JSON")
+	}
+}
+
+func TestLayoutTool_DuplicateIDsFails(t *testing.T) {
+	e := setup(t)
+	r := e.call(t, "layout", map[string]any{
+		"tree": map[string]any{
+			"id":   "root",
+			"type": "container",
+			"children": []any{
+				map[string]any{"id": "dup", "type": "text"},
+				map[string]any{"id": "dup", "type": "text"},
+			},
+		},
+	})
+	if !r.IsError {
+		t.Error("expected error for duplicate IDs")
+	}
+}
+
+func TestSetItemsTool_InvalidItemsJSON(t *testing.T) {
+	e := setup(t)
+	e.call(t, "layout", map[string]any{
+		"tree": map[string]any{
+			"id": "root", "type": "container",
+			"children": []any{
+				map[string]any{"id": "mylist", "type": "list"},
+			},
+		},
+	})
+	r := e.call(t, "set_items", map[string]any{
+		"target": "mylist",
+		"items":  "not-an-array",
+	})
+	if !r.IsError {
+		t.Error("expected error for invalid items JSON")
+	}
+}
+
+func TestAppendItemsTool_MissingTarget(t *testing.T) {
+	e := setup(t)
+	r := e.call(t, "append_items", map[string]any{
+		"items": []any{map[string]any{"id": "a", "label": "A"}},
+	})
+	if !r.IsError {
+		t.Error("expected error for missing target")
+	}
+}
+
+func TestAppendItemsTool_InvalidItemsJSON(t *testing.T) {
+	e := setup(t)
+	e.call(t, "layout", map[string]any{
+		"tree": map[string]any{
+			"id": "root", "type": "container",
+			"children": []any{
+				map[string]any{"id": "mylist", "type": "list"},
+			},
+		},
+	})
+	r := e.call(t, "append_items", map[string]any{
+		"target": "mylist",
+		"items":  "not-an-array",
+	})
+	if !r.IsError {
+		t.Error("expected error for invalid items JSON")
+	}
+}
+
+func TestAppendItemsTool_TargetNotFound(t *testing.T) {
+	e := setup(t)
+	r := e.call(t, "append_items", map[string]any{
+		"target": "nonexistent",
+		"items":  []any{map[string]any{"id": "a", "label": "A"}},
+	})
+	if !r.IsError {
+		t.Error("expected error for nonexistent target")
+	}
+}
+
+func TestRemoveItemsTool_MissingTarget(t *testing.T) {
+	e := setup(t)
+	r := e.call(t, "remove_items", map[string]any{
+		"keys": []any{"a"},
+	})
+	if !r.IsError {
+		t.Error("expected error for missing target")
+	}
+}
+
+func TestRemoveItemsTool_InvalidKeysJSON(t *testing.T) {
+	e := setup(t)
+	e.call(t, "layout", map[string]any{
+		"tree": map[string]any{
+			"id": "root", "type": "container",
+			"children": []any{
+				map[string]any{"id": "mylist", "type": "list"},
+			},
+		},
+	})
+	r := e.call(t, "remove_items", map[string]any{
+		"target": "mylist",
+		"keys":   "not-an-array",
+	})
+	if !r.IsError {
+		t.Error("expected error for invalid keys JSON")
+	}
+}
+
+func TestRemoveItemsTool_TargetNotFound(t *testing.T) {
+	e := setup(t)
+	r := e.call(t, "remove_items", map[string]any{
+		"target": "nonexistent",
+		"keys":   []any{"a"},
+	})
+	if !r.IsError {
+		t.Error("expected error for nonexistent target")
+	}
+}
+
+func TestToolsRejectBadUnmarshalArgs(t *testing.T) {
+	// Tools that parse structured input should return errors for malformed JSON args.
+	e := setup(t)
+
+	// Create a raw request with invalid JSON for the arguments field.
+	// We use CallTool via the MCP session with arguments that will fail
+	// struct unmarshaling (wrong types for known fields).
+	tools := []struct {
+		name string
+		args map[string]any
+	}{
+		{"patch", map[string]any{"ops": 42}},           // ops must be array
+		{"snapshot", map[string]any{"name": 42}},        // name must be string
+		{"restore", map[string]any{"name": 42}},         // name must be string
+		{"query", map[string]any{"ids": "not-array"}},   // ids must be array
+	}
+
+	for _, tc := range tools {
+		t.Run(tc.name, func(t *testing.T) {
+			r := e.call(t, tc.name, tc.args)
+			if !r.IsError {
+				t.Errorf("%s: expected error for bad args, got success: %s", tc.name, resultText(t, r))
+			}
+		})
+	}
+}
+
+func TestToolResponseStructSerialization(t *testing.T) {
+	// Verify that typed response structs serialize correctly and omit zero-value fields.
+	e := setup(t)
+
+	t.Run("patch_ok", func(t *testing.T) {
+		e2 := setupWithTree(t)
+		r := e2.call(t, "patch", map[string]any{
+			"ops": []any{map[string]any{
+				"op": "update", "id": "header",
+				"props": map[string]any{"text": "Updated"},
+			}},
+		})
+		m := resultMap(t, r)
+		if m["ok"] != true {
+			t.Error("expected ok: true")
+		}
+		// Should NOT have node_count, count, removed, etc.
+		if _, has := m["node_count"]; has {
+			t.Error("okResult should not include node_count")
+		}
+	})
+
+	t.Run("layout_with_node_count", func(t *testing.T) {
+		r := e.call(t, "layout", map[string]any{
+			"tree": map[string]any{
+				"id": "root", "type": "container",
+				"children": []any{
+					map[string]any{"id": "a", "type": "text"},
+					map[string]any{"id": "b", "type": "text"},
+				},
+			},
+		})
+		m := resultMap(t, r)
+		if m["ok"] != true {
+			t.Error("expected ok: true")
+		}
+		if m["node_count"].(float64) != 3 {
+			t.Errorf("expected node_count=3, got %v", m["node_count"])
+		}
+	})
+
+	t.Run("snapshot_with_name", func(t *testing.T) {
+		r := e.call(t, "snapshot", map[string]any{"name": "v1"})
+		m := resultMap(t, r)
+		if m["ok"] != true {
+			t.Error("expected ok: true")
+		}
+		if m["name"] != "v1" {
+			t.Errorf("expected name=v1, got %v", m["name"])
+		}
+	})
+
+	t.Run("restore_with_name", func(t *testing.T) {
+		r := e.call(t, "restore", map[string]any{"name": "v1"})
+		m := resultMap(t, r)
+		if m["ok"] != true {
+			t.Error("expected ok: true")
+		}
+		if m["restored"] != "v1" {
+			t.Errorf("expected restored=v1, got %v", m["restored"])
+		}
+	})
+
+	t.Run("timeout_result", func(t *testing.T) {
+		r := e.call(t, "await_event", map[string]any{"timeout_ms": 10})
+		m := resultMap(t, r)
+		if m["timeout"] != true {
+			t.Error("expected timeout: true")
+		}
+		if _, has := m["ok"]; has {
+			t.Error("timeout result should not have ok field")
+		}
+	})
+}
+
+func TestCallToolDirect(t *testing.T) {
+	s, err := NewServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+
+	t.Run("valid_tool", func(t *testing.T) {
+		r, err := s.CallTool(ctx, "describe_scripting", map[string]any{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if r.IsError {
+			t.Error("unexpected tool error")
+		}
+	})
+
+	t.Run("unknown_tool", func(t *testing.T) {
+		_, err := s.CallTool(ctx, "nonexistent", map[string]any{})
+		if err == nil {
+			t.Error("expected error for unknown tool")
+		}
+	})
+}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -1981,10 +1981,10 @@ func TestToolsRejectBadUnmarshalArgs(t *testing.T) {
 		name string
 		args map[string]any
 	}{
-		{"patch", map[string]any{"ops": 42}},           // ops must be array
-		{"snapshot", map[string]any{"name": 42}},        // name must be string
-		{"restore", map[string]any{"name": 42}},         // name must be string
-		{"query", map[string]any{"ids": "not-array"}},   // ids must be array
+		{"patch", map[string]any{"ops": 42}},          // ops must be array
+		{"snapshot", map[string]any{"name": 42}},      // name must be string
+		{"restore", map[string]any{"name": 42}},       // name must be string
+		{"query", map[string]any{"ids": "not-array"}}, // ids must be array
 	}
 
 	for _, tc := range tools {

--- a/internal/render/bridge.go
+++ b/internal/render/bridge.go
@@ -45,11 +45,11 @@ func (b *Bridge) NotifyDOMChanged() {
 }
 
 // NotifyConnected notifies the BubbleTea program that a new MCP client connected.
-func (b *Bridge) NotifyConnected() {
-	b.program.Send(MCPConnectedMsg{})
+func (b *Bridge) NotifyConnected(sessionID uint64) {
+	b.program.Send(MCPConnectedMsg{SessionID: sessionID})
 }
 
 // NotifyDisconnected notifies the BubbleTea program that MCP has disconnected.
-func (b *Bridge) NotifyDisconnected(err error) {
-	b.program.Send(MCPDisconnectedMsg{Err: err})
+func (b *Bridge) NotifyDisconnected(sessionID uint64, err error) {
+	b.program.Send(MCPDisconnectedMsg{SessionID: sessionID, Err: err})
 }

--- a/internal/render/bridge_test.go
+++ b/internal/render/bridge_test.go
@@ -45,13 +45,40 @@ func TestBridgeNotifiesDisconnect(t *testing.T) {
 	mp := &mockProgram{}
 	bridge := NewBridge(srv, mp)
 
-	bridge.NotifyDisconnected(nil)
+	bridge.NotifyDisconnected(7, nil)
 
 	if len(mp.msgs) != 1 {
 		t.Fatalf("expected 1 message, got %d", len(mp.msgs))
 	}
-	if _, ok := mp.msgs[0].(MCPDisconnectedMsg); !ok {
+	msg, ok := mp.msgs[0].(MCPDisconnectedMsg)
+	if !ok {
 		t.Errorf("expected MCPDisconnectedMsg, got %T", mp.msgs[0])
+	}
+	if msg.SessionID != 7 {
+		t.Errorf("SessionID = %d, want 7", msg.SessionID)
+	}
+}
+
+func TestBridgeNotifiesConnect(t *testing.T) {
+	srv, err := imcp.NewServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mp := &mockProgram{}
+	bridge := NewBridge(srv, mp)
+
+	bridge.NotifyConnected(9)
+
+	if len(mp.msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(mp.msgs))
+	}
+	msg, ok := mp.msgs[0].(MCPConnectedMsg)
+	if !ok {
+		t.Fatalf("expected MCPConnectedMsg, got %T", mp.msgs[0])
+	}
+	if msg.SessionID != 9 {
+		t.Errorf("SessionID = %d, want 9", msg.SessionID)
 	}
 }
 

--- a/internal/render/messages.go
+++ b/internal/render/messages.go
@@ -7,11 +7,14 @@ type DOMChangedMsg struct{}
 
 // MCPDisconnectedMsg is sent when the MCP connection breaks (e.g., broken pipe).
 type MCPDisconnectedMsg struct {
-	Err error
+	SessionID uint64
+	Err       error
 }
 
 // MCPConnectedMsg is sent when the MCP server is ready.
-type MCPConnectedMsg struct{}
+type MCPConnectedMsg struct {
+	SessionID uint64
+}
 
 // ShutdownMsg requests a graceful shutdown.
 type ShutdownMsg struct{}

--- a/internal/render/model.go
+++ b/internal/render/model.go
@@ -6,8 +6,10 @@ import (
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/joncooper/imagine-tui/internal/dom"
 	imcp "github.com/joncooper/imagine-tui/internal/mcp"
+	"github.com/joncooper/imagine-tui/internal/script"
 	"github.com/joncooper/imagine-tui/internal/widget"
 )
 
@@ -19,19 +21,24 @@ type Model struct {
 	focus   *FocusRing
 	logger  *slog.Logger
 
-	focusedID    string
-	width        int
-	height       int
-	disconnected bool
+	focusedID           string
+	width               int
+	height              int
+	activeSessionID     uint64
+	waitingForReconnect bool
+	scripts             *script.Runtime
+	scriptTree          *dom.Tree
+	knownNodes          map[string]bool
 }
 
 // NewModel creates a new render Model backed by the given MCP server and widget registry.
 func NewModel(srv *imcp.Server, registry *widget.Registry) Model {
 	return Model{
-		server:  srv,
-		widgets: widget.NewTree(registry),
-		focus:   &FocusRing{index: make(map[string]int)},
-		logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+		server:     srv,
+		widgets:    widget.NewTree(registry),
+		focus:      &FocusRing{index: make(map[string]int)},
+		logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+		knownNodes: make(map[string]bool),
 	}
 }
 
@@ -58,9 +65,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.KeyMsg:
 		m.logger.Info("key", "type", msg.Type, "runes", string(msg.Runes),
-			"focused", m.focusedID, "disconnected", m.disconnected)
+			"focused", m.focusedID, "waiting_for_reconnect", m.waitingForReconnect)
 		// Allow 'q' or Esc to quit when disconnected or no DOM loaded.
-		if m.disconnected || m.server.Tree() == nil {
+		if m.waitingForReconnect || m.server.Tree() == nil {
 			if msg.Type == tea.KeyRunes && string(msg.Runes) == "q" || msg.Type == tea.KeyEsc {
 				m.server.Shutdown()
 				return m, tea.Quit
@@ -70,7 +77,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case DOMChangedMsg:
 		m.logger.Info("DOM changed, syncing state")
-		m.syncState()
+		if err := m.refreshScriptsAndWidgets(); err != nil {
+			m.logger.Error("script sync failed", "error", err)
+			m.syncState()
+		}
 		// If focused node was removed, adjust focus.
 		if m.focusedID != "" && !m.focus.Contains(m.focusedID) {
 			m.focusedID = m.focus.Next("")
@@ -84,14 +94,23 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case MCPDisconnectedMsg:
-		m.logger.Info("MCP disconnected", "error", msg.Err)
-		m.disconnected = true
+		if msg.SessionID != 0 && msg.SessionID != m.activeSessionID {
+			m.logger.Info("ignoring stale MCP disconnect", "session_id", msg.SessionID, "active_session_id", m.activeSessionID, "error", msg.Err)
+			return m, nil
+		}
+		m.logger.Info("MCP disconnected", "session_id", msg.SessionID, "error", msg.Err)
+		m.activeSessionID = 0
+		m.waitingForReconnect = true
 		return m, nil
 
 	case MCPConnectedMsg:
-		m.logger.Info("MCP connected")
-		m.disconnected = false
-		m.syncState()
+		m.logger.Info("MCP connected", "session_id", msg.SessionID)
+		m.activeSessionID = msg.SessionID
+		m.waitingForReconnect = false
+		if err := m.refreshScriptsAndWidgets(); err != nil {
+			m.logger.Error("script sync failed", "error", err)
+			m.syncState()
+		}
 		return m, nil
 
 	case ShutdownMsg:
@@ -109,17 +128,21 @@ func (m Model) View() string {
 		return ""
 	}
 
-	if m.disconnected {
-		return m.renderDisconnected()
-	}
-
 	m.server.RLock()
 	defer m.server.RUnlock()
 	tree := m.server.Tree()
 	m.logger.Debug("view: rendering", "root_children", len(tree.Root.Children),
 		"width", m.width, "height", m.height)
-	result := m.widgets.Render(tree, m.width, m.height, m.focusedID)
+	var result string
+	if len(tree.Root.Children) == 0 {
+		result = m.renderIdleScreen()
+	} else {
+		result = m.widgets.Render(tree, m.width, m.height, m.focusedID)
+	}
 	m.logger.Debug("view: done", "output_len", len(result))
+	if m.waitingForReconnect {
+		return m.renderReconnectBanner(result)
+	}
 	return result
 }
 
@@ -146,18 +169,19 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, tea.Quit
 
 	default:
-		m.server.RLock()
-		defer m.server.RUnlock()
-
 		switch msg.Type {
 		case tea.KeyTab:
+			oldFocus := m.focusedID
 			m.focusedID = m.focusTab(true)
 			m.logger.Info("tab focus", "new_focus", m.focusedID)
+			m.runFocusHooks(oldFocus, m.focusedID)
 			return m, nil
 
 		case tea.KeyShiftTab:
+			oldFocus := m.focusedID
 			m.focusedID = m.focusTab(false)
 			m.logger.Info("shift-tab focus", "new_focus", m.focusedID)
+			m.runFocusHooks(oldFocus, m.focusedID)
 			return m, nil
 
 		default:
@@ -192,6 +216,21 @@ func (m Model) routeKeyToWidget(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
+	keyHookRan := m.runKeyHook(node.ID, msg)
+	if keyHookRan {
+		node = m.server.Tree().Find(m.focusedID)
+		if node == nil {
+			return m, nil
+		}
+		if node.Type == dom.TypeButton && (msg.Type == tea.KeyEnter || msg.Type == tea.KeySpace) {
+			return m, nil
+		}
+		w = m.widgets.Get(m.focusedID)
+		if w == nil {
+			return m, nil
+		}
+	}
+
 	result := w.Update(msg, node)
 
 	// Process widget events.
@@ -203,9 +242,56 @@ func (m Model) routeKeyToWidget(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 }
 
 // routeWidgetEvent routes a widget event to the appropriate destination:
-// scripts first, then if the event should be Claude-routed, enqueue it.
+// scripts first, then if the event should be agent-routed, enqueue it.
 func (m *Model) routeWidgetEvent(evt widget.Event) {
-	// Enqueue as a Claude-routed event.
+	node := m.server.Tree().Find(evt.NodeID)
+	if node == nil {
+		return
+	}
+
+	refreshNeeded := false
+	handled := false
+
+	switch evt.Type {
+	case "change":
+		if selected, ok := evt.Data["selected"]; ok {
+			node.SetProp("value", selected)
+		}
+		refreshNeeded = true
+		if m.hasHook(evt.NodeID, script.HookOnChange) {
+			refreshNeeded = true
+			handled = true
+			value, ok := evt.Data["value"]
+			if !ok {
+				value = evt.Data["selected"]
+			}
+			if err := m.scripts.NotifyChange(evt.NodeID, value); err != nil {
+				m.logger.Error("script on_change failed", "node_id", evt.NodeID, "error", err)
+			}
+		}
+	case "submit":
+		if m.hasHook(evt.NodeID, script.HookOnSubmit) {
+			refreshNeeded = true
+			payload := &script.HookPayload{Data: evt.Data}
+			if _, err := m.scripts.ExecHook(evt.NodeID, script.HookOnSubmit, payload); err != nil {
+				m.logger.Error("script on_submit failed", "node_id", evt.NodeID, "error", err)
+			}
+		}
+	}
+
+	if m.runEventHooks(node, evt) {
+		refreshNeeded = true
+	}
+	if refreshNeeded {
+		if err := m.refreshScriptsAndWidgets(); err != nil {
+			m.logger.Error("script refresh failed", "source", evt.NodeID, "error", err)
+		}
+	}
+	if handled {
+		return
+	}
+
+	// Enqueue as an agent-routed event.
 	domEvt := &dom.Event{
 		Type:   evt.Type,
 		Source: evt.NodeID,
@@ -251,22 +337,271 @@ func (m *Model) collectContext(sourceID string) map[string]map[string]any {
 	return ctx
 }
 
-// renderDisconnected shows a disconnect message centered in the viewport.
-func (m Model) renderDisconnected() string {
-	msg := "MCP server disconnected"
-	pad := (m.width - len(msg)) / 2
-	if pad < 0 {
-		pad = 0
+func (m *Model) ensureScriptRuntime() {
+	tree := m.server.Tree()
+	if tree == nil {
+		return
 	}
-	line := strings.Repeat(" ", pad) + msg
-	lines := make([]string, m.height)
-	mid := m.height / 2
-	for i := range lines {
-		if i == mid {
-			lines[i] = line
-		} else {
-			lines[i] = ""
+	if m.scripts != nil && m.scriptTree == tree {
+		return
+	}
+
+	m.scriptTree = tree
+	m.scripts = script.New(tree, m.server.Events())
+	m.knownNodes = make(map[string]bool)
+}
+
+func (m *Model) refreshScriptsAndWidgets() error {
+	m.ensureScriptRuntime()
+	if m.scripts != nil {
+		if err := m.reconcileScriptTree(); err != nil {
+			return err
+		}
+		if err := m.scripts.EvalAllComputed(); err != nil {
+			return err
 		}
 	}
-	return strings.Join(lines, "\n")
+	m.syncState()
+	return nil
+}
+
+func (m *Model) reconcileScriptTree() error {
+	const maxIterations = 32
+	for i := 0; i < maxIterations; i++ {
+		order, live := m.collectNodeOrder()
+		for id := range m.knownNodes {
+			if !live[id] {
+				m.scripts.NotifyRemove(id)
+				delete(m.knownNodes, id)
+			}
+		}
+
+		var added []string
+		for _, id := range order {
+			if !m.knownNodes[id] {
+				added = append(added, id)
+			}
+		}
+		if len(added) == 0 {
+			return nil
+		}
+
+		for _, id := range added {
+			m.knownNodes[id] = true
+			if err := m.scripts.NotifyMount(id); err != nil {
+				return err
+			}
+		}
+	}
+
+	return &script.Error{Hook: "on_mount", Message: "mount reconciliation exceeded iteration limit"}
+}
+
+func (m *Model) collectNodeOrder() ([]string, map[string]bool) {
+	tree := m.server.Tree()
+	if tree == nil {
+		return nil, nil
+	}
+
+	var order []string
+	live := make(map[string]bool)
+	tree.Walk(func(n *dom.Node) bool {
+		order = append(order, n.ID)
+		live[n.ID] = true
+		return true
+	})
+	return order, live
+}
+
+func (m *Model) hasHook(nodeID string, hook script.HookType) bool {
+	m.ensureScriptRuntime()
+	node := m.server.Tree().Find(nodeID)
+	if node == nil {
+		return false
+	}
+	body, ok := node.Scripts[string(hook)]
+	return ok && body != ""
+}
+
+func (m *Model) runKeyHook(nodeID string, msg tea.KeyMsg) bool {
+	if !m.hasHook(nodeID, script.HookOnKey) {
+		return false
+	}
+	if _, err := m.scripts.ExecHook(nodeID, script.HookOnKey, &script.HookPayload{Key: msg.String()}); err != nil {
+		m.logger.Error("script on_key failed", "node_id", nodeID, "error", err)
+	}
+	if err := m.refreshScriptsAndWidgets(); err != nil {
+		m.logger.Error("script refresh failed", "node_id", nodeID, "error", err)
+	}
+	return true
+}
+
+func (m *Model) runFocusHooks(oldFocus, newFocus string) {
+	ran := false
+	if oldFocus != "" && m.hasHook(oldFocus, script.HookOnBlur) {
+		if _, err := m.scripts.ExecHook(oldFocus, script.HookOnBlur, nil); err != nil {
+			m.logger.Error("script on_blur failed", "node_id", oldFocus, "error", err)
+		}
+		ran = true
+	}
+	if newFocus != "" && m.hasHook(newFocus, script.HookOnFocus) {
+		if _, err := m.scripts.ExecHook(newFocus, script.HookOnFocus, nil); err != nil {
+			m.logger.Error("script on_focus failed", "node_id", newFocus, "error", err)
+		}
+		ran = true
+	}
+	if ran {
+		if err := m.refreshScriptsAndWidgets(); err != nil {
+			m.logger.Error("script refresh failed", "old_focus", oldFocus, "new_focus", newFocus, "error", err)
+		}
+	}
+}
+
+func (m *Model) runEventHooks(node *dom.Node, evt widget.Event) bool {
+	if m.scripts == nil {
+		m.ensureScriptRuntime()
+	}
+	if m.scripts == nil || node == nil {
+		return false
+	}
+
+	ran := false
+	payload := &script.HookPayload{
+		Event:  evt.Type,
+		Source: evt.NodeID,
+		Data:   evt.Data,
+	}
+	for parent := node.Parent(); parent != nil; parent = parent.Parent() {
+		body, ok := parent.Scripts[string(script.HookOnEvent)]
+		if !ok || body == "" {
+			continue
+		}
+		if _, err := m.scripts.ExecHook(parent.ID, script.HookOnEvent, payload); err != nil {
+			m.logger.Error("script on_event failed", "node_id", parent.ID, "source", evt.NodeID, "error", err)
+		}
+		ran = true
+	}
+	return ran
+}
+
+func (m Model) renderReconnectBanner(content string) string {
+	return m.renderModalOverlay(content, "Imagine TUI", "Agent disconnected.\nWaiting for reconnect...")
+}
+
+func (m Model) renderIdleScreen() string {
+	status := "Waiting for agent..."
+	if m.activeSessionID != 0 && !m.waitingForReconnect {
+		status = "Agent connected."
+	}
+
+	return m.renderStatusScreen("Imagine TUI", status)
+}
+
+func (m Model) renderStatusScreen(title, status string) string {
+	titleStyle := lipgloss.NewStyle().Bold(true).Align(lipgloss.Center)
+	bodyStyle := lipgloss.NewStyle().Faint(true).Align(lipgloss.Center)
+	boxStyle := statusBoxStyle(title, status)
+
+	box := lipgloss.JoinVertical(
+		lipgloss.Center,
+		titleStyle.Render(title),
+		bodyStyle.Render(status),
+	)
+
+	return lipgloss.Place(
+		m.width,
+		m.height,
+		lipgloss.Center,
+		lipgloss.Center,
+		boxStyle.Render(box),
+	)
+}
+
+func (m Model) renderModalOverlay(content, title, status string) string {
+	boxStyle := statusBoxStyle(title, status)
+	titleStyle := lipgloss.NewStyle().Bold(true).Align(lipgloss.Center)
+	bodyStyle := lipgloss.NewStyle().Faint(true).Align(lipgloss.Center)
+
+	box := lipgloss.JoinVertical(
+		lipgloss.Center,
+		titleStyle.Render(title),
+		bodyStyle.Render(status),
+	)
+	baseLines := strings.Split(content, "\n")
+	for len(baseLines) < m.height {
+		baseLines = append(baseLines, "")
+	}
+	if len(baseLines) > m.height {
+		baseLines = baseLines[:m.height]
+	}
+	for i := range baseLines {
+		baseLines[i] = padOverlayLine(baseLines[i], m.width)
+	}
+
+	modalLines := strings.Split(boxStyle.Render(box), "\n")
+	startRow := (m.height - len(modalLines)) / 2
+	if startRow < 0 {
+		startRow = 0
+	}
+
+	for i, modalLine := range modalLines {
+		row := startRow + i
+		if row >= len(baseLines) {
+			break
+		}
+		baseLines[row] = overlayLine(baseLines[row], modalLine, m.width)
+	}
+
+	return strings.Join(baseLines, "\n")
+}
+
+func padOverlayLine(line string, width int) string {
+	if width <= 0 {
+		return line
+	}
+	if pad := width - lipgloss.Width(line); pad > 0 {
+		return line + strings.Repeat(" ", pad)
+	}
+	return line
+}
+
+func overlayLine(base, overlay string, width int) string {
+	if width <= 0 {
+		return base
+	}
+
+	baseRunes := []rune(padOverlayLine(base, width))
+	if len(baseRunes) < width {
+		baseRunes = append(baseRunes, []rune(strings.Repeat(" ", width-len(baseRunes)))...)
+	}
+
+	overlayRunes := []rune(overlay)
+	startCol := (width - lipgloss.Width(overlay)) / 2
+	if startCol < 0 {
+		startCol = 0
+	}
+	if startCol >= len(baseRunes) {
+		return string(baseRunes)
+	}
+	if max := len(baseRunes) - startCol; len(overlayRunes) > max {
+		overlayRunes = overlayRunes[:max]
+	}
+	copy(baseRunes[startCol:startCol+len(overlayRunes)], overlayRunes)
+	return string(baseRunes)
+}
+
+func statusBoxStyle(title, status string) lipgloss.Style {
+	width := 28
+	for _, line := range append([]string{title}, strings.Split(status, "\n")...) {
+		lineWidth := lipgloss.Width(line) + 6
+		if lineWidth > width {
+			width = lineWidth
+		}
+	}
+
+	return lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		Padding(1, 3).
+		Width(width).
+		Align(lipgloss.Center)
 }

--- a/internal/render/model.go
+++ b/internal/render/model.go
@@ -54,7 +54,12 @@ func (m Model) Init() tea.Cmd {
 }
 
 // Update implements tea.Model. Routes messages to the appropriate handler.
+// Acquires the server's write lock for the duration of the update to serialize
+// with concurrent MCP handler goroutines that also mutate the DOM under Lock.
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	m.server.Lock()
+	defer m.server.Unlock()
+
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		m.logger.Info("window resize", "width", msg.Width, "height", msg.Height)
@@ -147,9 +152,8 @@ func (m Model) View() string {
 }
 
 // syncState synchronizes the widget tree and focus ring with the current DOM.
+// Callers must hold the server's Lock or RLock.
 func (m *Model) syncState() {
-	m.server.RLock()
-	defer m.server.RUnlock()
 	tree := m.server.Tree()
 	m.logger.Debug("syncState", "root_children", len(tree.Root.Children),
 		"tree_summary", tree.Summary())
@@ -160,37 +164,34 @@ func (m *Model) syncState() {
 	m.logger.Debug("focus ring built", "size", len(m.focus.IDs), "ids", m.focus.IDs)
 }
 
-// handleKey processes keyboard input. Acquires a read lock on the server to
-// protect against concurrent MCP mutations while reading the DOM tree.
+// handleKey processes keyboard input. Must be called under the server's Lock
+// (held by Update).
 func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.Type {
 	case tea.KeyCtrlC:
 		m.server.Shutdown()
 		return m, tea.Quit
 
+	case tea.KeyTab:
+		oldFocus := m.focusedID
+		m.focusedID = m.focusTab(true)
+		m.logger.Info("tab focus", "new_focus", m.focusedID)
+		m.runFocusHooks(oldFocus, m.focusedID)
+		return m, nil
+
+	case tea.KeyShiftTab:
+		oldFocus := m.focusedID
+		m.focusedID = m.focusTab(false)
+		m.logger.Info("shift-tab focus", "new_focus", m.focusedID)
+		m.runFocusHooks(oldFocus, m.focusedID)
+		return m, nil
+
 	default:
-		switch msg.Type {
-		case tea.KeyTab:
-			oldFocus := m.focusedID
-			m.focusedID = m.focusTab(true)
-			m.logger.Info("tab focus", "new_focus", m.focusedID)
-			m.runFocusHooks(oldFocus, m.focusedID)
-			return m, nil
-
-		case tea.KeyShiftTab:
-			oldFocus := m.focusedID
-			m.focusedID = m.focusTab(false)
-			m.logger.Info("shift-tab focus", "new_focus", m.focusedID)
-			m.runFocusHooks(oldFocus, m.focusedID)
-			return m, nil
-
-		default:
-			// Route to focused widget.
-			if m.focusedID != "" {
-				return m.routeKeyToWidget(msg)
-			}
-			return m, nil
+		// Route to focused widget.
+		if m.focusedID != "" {
+			return m.routeKeyToWidget(msg)
 		}
+		return m, nil
 	}
 }
 

--- a/internal/render/model.go
+++ b/internal/render/model.go
@@ -397,20 +397,19 @@ func (m *Model) reconcileScriptTree() error {
 	return &script.Error{Hook: "on_mount", Message: "mount reconciliation exceeded iteration limit"}
 }
 
-func (m *Model) collectNodeOrder() ([]string, map[string]bool) {
+func (m *Model) collectNodeOrder() (order []string, live map[string]bool) {
 	tree := m.server.Tree()
 	if tree == nil {
 		return nil, nil
 	}
 
-	var order []string
-	live := make(map[string]bool)
+	live = make(map[string]bool)
 	tree.Walk(func(n *dom.Node) bool {
 		order = append(order, n.ID)
 		live[n.ID] = true
 		return true
 	})
-	return order, live
+	return
 }
 
 func (m *Model) hasHook(nodeID string, hook script.HookType) bool {
@@ -583,8 +582,8 @@ func overlayLine(base, overlay string, width int) string {
 	if startCol >= len(baseRunes) {
 		return string(baseRunes)
 	}
-	if max := len(baseRunes) - startCol; len(overlayRunes) > max {
-		overlayRunes = overlayRunes[:max]
+	if avail := len(baseRunes) - startCol; len(overlayRunes) > avail {
+		overlayRunes = overlayRunes[:avail]
 	}
 	copy(baseRunes[startCol:startCol+len(overlayRunes)], overlayRunes)
 	return string(baseRunes)

--- a/internal/render/model_test.go
+++ b/internal/render/model_test.go
@@ -211,16 +211,37 @@ func TestModelZeroSizeReturnsEmpty(t *testing.T) {
 func TestModelMCPDisconnectedMsg(t *testing.T) {
 	m, _ := newTestModelWithTree(t)
 
-	newM, _ := m.Update(MCPDisconnectedMsg{})
+	newM, _ := m.Update(MCPConnectedMsg{SessionID: 1})
 	model := newM.(Model)
+	newM2, _ := model.Update(MCPDisconnectedMsg{SessionID: 1})
+	model2 := newM2.(Model)
 
-	if !model.disconnected {
-		t.Error("expected disconnected = true")
+	if !model2.waitingForReconnect {
+		t.Error("expected waitingForReconnect = true")
 	}
 
-	view := model.View()
-	if !strings.Contains(view, "disconnected") {
-		t.Errorf("view should show disconnect message, got:\n%s", view)
+	view := model2.View()
+	if !strings.Contains(view, "Agent disconnected.") {
+		t.Errorf("view should show reconnect modal, got:\n%s", view)
+	}
+	if !strings.Contains(view, "Hello") {
+		t.Errorf("view should preserve last rendered UI, got:\n%s", view)
+	}
+}
+
+func TestModelIgnoresStaleDisconnect(t *testing.T) {
+	m, _ := newTestModelWithTree(t)
+
+	newM, _ := m.Update(MCPConnectedMsg{SessionID: 2})
+	model := newM.(Model)
+	newM2, _ := model.Update(MCPDisconnectedMsg{SessionID: 1})
+	model2 := newM2.(Model)
+
+	if model2.waitingForReconnect {
+		t.Error("stale disconnect should be ignored")
+	}
+	if model2.activeSessionID != 2 {
+		t.Errorf("activeSessionID = %d, want 2", model2.activeSessionID)
 	}
 }
 

--- a/internal/render/script_live_test.go
+++ b/internal/render/script_live_test.go
@@ -1,0 +1,161 @@
+package render
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	imcp "github.com/joncooper/imagine-tui/internal/mcp"
+	"github.com/joncooper/imagine-tui/internal/widget"
+)
+
+func TestRenderRunsMountAndComputedScriptsOnDOMChange(t *testing.T) {
+	srv, err := imcp.NewServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Shutdown()
+
+	m := NewModel(srv, widget.DefaultRegistry())
+	m.width = 80
+	m.height = 24
+
+	callTool(t, srv, "replace", map[string]any{
+		"tree": map[string]any{
+			"id":   "root",
+			"type": "container",
+			"children": []any{
+				map[string]any{
+					"id":    "name",
+					"type":  "input",
+					"props": map[string]any{"value": "alpha"},
+				},
+				map[string]any{
+					"id":       "computed",
+					"type":     "text",
+					"computed": map[string]any{"text": "return $('name').value.toUpperCase()"},
+				},
+				map[string]any{
+					"id":      "mounted",
+					"type":    "text",
+					"props":   map[string]any{"text": "pending"},
+					"scripts": map[string]any{"on_mount": "$.text = 'mounted'"},
+				},
+			},
+		},
+	})
+
+	newM, _ := m.Update(DOMChangedMsg{})
+	model := newM.(Model)
+	view := model.View()
+	if !strings.Contains(view, "ALPHA") {
+		t.Errorf("computed prop not rendered, got:\n%s", view)
+	}
+	if !strings.Contains(view, "mounted") {
+		t.Errorf("mount hook not rendered, got:\n%s", view)
+	}
+}
+
+func TestRenderRunsOnChangeScriptsAndQueuesAgentEvents(t *testing.T) {
+	srv, err := imcp.NewServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Shutdown()
+
+	m := NewModel(srv, widget.DefaultRegistry())
+	m.width = 80
+	m.height = 24
+
+	callTool(t, srv, "replace", map[string]any{
+		"tree": map[string]any{
+			"id":   "root",
+			"type": "container",
+			"children": []any{
+				map[string]any{
+					"id":    "status",
+					"type":  "text",
+					"props": map[string]any{"text": "idle"},
+				},
+				map[string]any{
+					"id":   "search",
+					"type": "input",
+					"scripts": map[string]any{
+						"on_change": "emit('local', [{op: 'update', id: 'status', props: {text: 'query:' + $.value}}]); emit('agent', {action: 'filter', query: $.value})",
+					},
+				},
+			},
+		},
+	})
+
+	newM, _ := m.Update(DOMChangedMsg{})
+	model := newM.(Model)
+	model.focusedID = "search"
+
+	newM2, _ := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	model2 := newM2.(Model)
+	view := model2.View()
+	if !strings.Contains(view, "query:x") {
+		t.Errorf("local patch from script not rendered, got:\n%s", view)
+	}
+
+	result := callTool(t, srv, "await_event", map[string]any{"timeout_ms": 50})
+	text := resultText(t, result)
+	if !strings.Contains(text, "\"action\":\"filter\"") {
+		t.Errorf("expected agent event payload, got: %s", text)
+	}
+	if !strings.Contains(text, "\"source\":\"search\"") {
+		t.Errorf("expected script event source, got: %s", text)
+	}
+}
+
+func TestRenderRunsOnKeyScriptsWithoutButtonClickFallback(t *testing.T) {
+	srv, err := imcp.NewServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Shutdown()
+
+	m := NewModel(srv, widget.DefaultRegistry())
+	m.width = 80
+	m.height = 24
+
+	callTool(t, srv, "replace", map[string]any{
+		"tree": map[string]any{
+			"id":   "root",
+			"type": "container",
+			"children": []any{
+				map[string]any{
+					"id":    "status",
+					"type":  "text",
+					"props": map[string]any{"text": "idle"},
+				},
+				map[string]any{
+					"id":    "action",
+					"type":  "button",
+					"props": map[string]any{"label": "Launch"},
+					"scripts": map[string]any{
+						"on_key": "$.props.label = 'Pressed'; emit('local', [{op: 'update', id: 'status', props: {text: 'armed'}}])",
+					},
+				},
+			},
+		},
+	})
+
+	newM, _ := m.Update(DOMChangedMsg{})
+	model := newM.(Model)
+	model.focusedID = "action"
+
+	newM2, _ := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model2 := newM2.(Model)
+	view := model2.View()
+	if !strings.Contains(view, "Pressed") || !strings.Contains(view, "armed") {
+		t.Errorf("on_key script did not update view, got:\n%s", view)
+	}
+
+	result := callTool(t, srv, "await_event", map[string]any{"timeout_ms": 10})
+	text := resultText(t, result)
+	if !strings.Contains(text, "timeout") {
+		t.Errorf("expected no fallback click event, got: %s", text)
+	}
+}

--- a/internal/script/emit.go
+++ b/internal/script/emit.go
@@ -21,10 +21,10 @@ func (rt *Runtime) makeEmitFn(sourceNodeID string) func(goja.FunctionCall) goja.
 		switch target {
 		case "local":
 			rt.emitLocal(call.Arguments[1])
-		case "claude":
-			rt.emitClaude(sourceNodeID, call.Arguments[1])
+		case "agent", "claude":
+			rt.emitAgent(sourceNodeID, call.Arguments[1])
 		default:
-			panic(rt.vm.NewTypeError(fmt.Sprintf("emit: invalid target %q (expected 'local' or 'claude')", target)))
+			panic(rt.vm.NewTypeError(fmt.Sprintf("emit: invalid target %q (expected 'local', 'agent', or deprecated 'claude')", target)))
 		}
 
 		return goja.Undefined()
@@ -47,8 +47,8 @@ func (rt *Runtime) emitLocal(opsVal goja.Value) {
 	}
 }
 
-// emitClaude enqueues an event for Claude Code via the event queue.
-func (rt *Runtime) emitClaude(sourceNodeID string, dataVal goja.Value) {
+// emitAgent enqueues an event for the MCP client via the event queue.
+func (rt *Runtime) emitAgent(sourceNodeID string, dataVal goja.Value) {
 	var data map[string]any
 	if exported, ok := dataVal.Export().(map[string]any); ok {
 		data = exported

--- a/internal/script/emit_test.go
+++ b/internal/script/emit_test.go
@@ -85,11 +85,11 @@ func TestEmitLocalInsertNode(t *testing.T) {
 	}
 }
 
-func TestEmitClaudeEnqueuesEvent(t *testing.T) {
+func TestEmitAgentEnqueuesEvent(t *testing.T) {
 	rt := newTestRuntimeWithTree(t)
 
 	err := rt.execScript("child1", "test", `
-		emit('claude', {action: 'submit', detail: 'test_data'})
+		emit('agent', {action: 'submit', detail: 'test_data'})
 	`, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -117,11 +117,11 @@ func TestEmitClaudeEnqueuesEvent(t *testing.T) {
 	}
 }
 
-func TestEmitClaudeWithNestedData(t *testing.T) {
+func TestEmitAgentWithNestedData(t *testing.T) {
 	rt := newTestRuntimeWithTree(t)
 
 	err := rt.execScript("root", "test", `
-		emit('claude', {items: [1, 2, 3], nested: {key: 'val'}})
+		emit('agent', {items: [1, 2, 3], nested: {key: 'val'}})
 	`, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -137,6 +137,27 @@ func TestEmitClaudeWithNestedData(t *testing.T) {
 	items, ok := evt.Data["items"].([]any)
 	if !ok || len(items) != 3 {
 		t.Errorf("expected items=[1,2,3], got %v", evt.Data["items"])
+	}
+}
+
+func TestEmitClaudeAliasStillEnqueuesEvent(t *testing.T) {
+	rt := newTestRuntimeWithTree(t)
+
+	err := rt.execScript("child1", "test", `
+		emit('claude', {action: 'legacy'})
+	`, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	evt, err := rt.events.Dequeue(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if evt.Data["action"] != "legacy" {
+		t.Errorf("expected legacy action, got %v", evt.Data["action"])
 	}
 }
 

--- a/internal/script/hooks.go
+++ b/internal/script/hooks.go
@@ -7,6 +7,7 @@ type HookType string
 const (
 	HookOnMount  HookType = "on_mount"
 	HookOnChange HookType = "on_change"
+	HookOnSubmit HookType = "on_submit"
 	HookOnEvent  HookType = "on_event"
 	HookOnFocus  HookType = "on_focus"
 	HookOnBlur   HookType = "on_blur"

--- a/internal/script/hooks_test.go
+++ b/internal/script/hooks_test.go
@@ -258,11 +258,11 @@ func TestNotifyChangeNodeNotFound(t *testing.T) {
 	}
 }
 
-func TestExecHookEmitsClaude(t *testing.T) {
+func TestExecHookEmitsAgent(t *testing.T) {
 	rt := newTestRuntimeWithTree(t)
 
 	node := rt.tree.Find("child1")
-	node.Scripts["on_mount"] = `emit('claude', {action: 'mounted'})`
+	node.Scripts["on_mount"] = `emit('agent', {action: 'mounted'})`
 
 	_, err := rt.ExecHook("child1", HookOnMount, nil)
 	if err != nil {
@@ -286,7 +286,7 @@ func TestExecHookEmitsClaude(t *testing.T) {
 func TestHookTypesAllValid(t *testing.T) {
 	// Verify all hook type constants are defined.
 	hooks := []HookType{
-		HookOnMount, HookOnChange, HookOnEvent,
+		HookOnMount, HookOnChange, HookOnSubmit, HookOnEvent,
 		HookOnFocus, HookOnBlur, HookOnKey,
 	}
 	for _, h := range hooks {

--- a/internal/script/integration_test.go
+++ b/internal/script/integration_test.go
@@ -40,7 +40,7 @@ func TestIntegrationFullStack(t *testing.T) {
 	btn, _ := dom.NewNode("submit_btn", dom.TypeButton)
 	btn.SetProp("label", "Submit")
 	// on_mount script emits to Claude.
-	btn.Scripts["on_mount"] = `emit('claude', {action: 'btn_ready'})`
+	btn.Scripts["on_mount"] = `emit('agent', {action: 'btn_ready'})`
 	_ = tree.Insert("form", btn, "")
 
 	events := dom.NewEventQueue()
@@ -56,7 +56,7 @@ func TestIntegrationFullStack(t *testing.T) {
 		t.Errorf("initial total: expected 'Total: $20', got %v", v)
 	}
 
-	// Step 2: Fire on_mount for submit button → should emit claude event.
+	// Step 2: Fire on_mount for submit button → should emit agent event.
 	err = rt.NotifyMount("submit_btn")
 	if err != nil {
 		t.Fatalf("NotifyMount: %v", err)

--- a/internal/widget/input.go
+++ b/internal/widget/input.go
@@ -111,6 +111,11 @@ func (w *InputWidget) Update(msg tea.Msg, node *dom.Node) UpdateResult {
 		}
 		w.value = string(runes)
 
+	case tea.KeySpace:
+		runes = append(runes[:w.cursorPos], append([]rune{' '}, runes[w.cursorPos:]...)...)
+		w.cursorPos++
+		w.value = string(runes)
+
 	default:
 		return UpdateResult{}
 	}

--- a/internal/widget/input_test.go
+++ b/internal/widget/input_test.go
@@ -137,6 +137,29 @@ func TestInputWidget_Update_ChangeEvent(t *testing.T) {
 	}
 }
 
+func TestInputWidget_Update_SpaceKey(t *testing.T) {
+	w := &InputWidget{}
+	n := inputNode(t, map[string]any{"value": "survey"})
+	w.Init(n)
+
+	result := w.Update(tea.KeyMsg{Type: tea.KeySpace}, n)
+	if !result.Consumed {
+		t.Error("expected space key to be consumed")
+	}
+	if w.value != "survey " {
+		t.Errorf("value = %q, want %q", w.value, "survey ")
+	}
+	if got, _ := n.GetProp("value"); got != "survey " {
+		t.Errorf("node prop value = %v, want %q", got, "survey ")
+	}
+	if len(result.Events) != 1 || result.Events[0].Type != "change" {
+		t.Fatalf("expected one change event, got %#v", result.Events)
+	}
+	if result.Events[0].Data["value"] != "survey " {
+		t.Errorf("change event value = %v, want %q", result.Events[0].Data["value"], "survey ")
+	}
+}
+
 func TestInputWidget_Validation_ValidPattern(t *testing.T) {
 	w := &InputWidget{}
 	n := inputNode(t, map[string]any{"value": "abc", "pattern": "^[a-z]+$"})


### PR DESCRIPTION
## Summary
Add render pipeline with socket server and on_submit hooks, comprehensive E2E testing framework, and MCP server refactoring with typed schemas.

- Implements socket-based communication between MCP server and BubbleTea renderer
- Adds on_submit hook support for form submission events
- E2E test infrastructure with agent ownership, log viewer, and bridge tests
- Refactored MCP tool registration with typed JSON schemas
- Fixed golangci-lint issues and improved test coverage across dom, script, and render packages
- Updated docs and CI configuration