### PR TITLE
Add sandboxed script timers

### DIFF
--- a/docs/SCRIPT_RUNTIME.md
+++ b/docs/SCRIPT_RUNTIME.md
@@ -65,7 +65,7 @@ func (rt *Runtime) NotifyChange(nodeID string, newValue any) error
 **Files:** `runtime.go`, `errors.go`, `sandbox_test.go`
 
 - [x] `Runtime` struct with `New()` constructor, `goja.Runtime` init
-- [x] `initSandbox()`: delete `require`, `console`, `fetch`, `setTimeout`, `setInterval`, `process`, `globalThis`; provide `debug()` routing to server log
+- [x] `initSandbox()`: delete `require`, `console`, `fetch`, `process`, `globalThis`; provide `debug()` routing to server log
 - [x] Timeout mechanism: `time.AfterFunc(rt.timeout, func() { rt.vm.Interrupt(...) })` + `vm.ClearInterrupt()`
 - [x] `Error` type (renamed from `ScriptError` per lint) with `NodeID`, `Hook`, `Message`, `IsTimeout`
 - [x] Test: forbidden API access returns error (not panic)
@@ -160,6 +160,23 @@ func (rt *Runtime) NotifyChange(nodeID string, newValue any) error
 - [x] Test: error in expression → Error with node ID
 - [x] Test: computed prop depending on another computed prop (transitive deps)
 - [x] Test: EvalAllComputed evaluates all computed props in tree
+
+### Step 8: M3-8 — Timers
+**Files:** `timer.go`, `timer_test.go`, `runtime.go`, `hooks.go`, `internal/render/model.go`
+
+- [x] Timer state added to `Runtime` with per-node ownership tracking
+- [x] `setTimeout`, `setInterval`, `clearTimeout`, and `clearInterval` exposed in the sandbox
+- [x] Delays above the configured max timer duration are rejected
+- [x] Max concurrent timers enforced at registration time
+- [x] `RunDueTimers()` executes callbacks under the existing serialized VM lock
+- [x] `NextTimerAt()` exposes the next due timer for Bubble Tea scheduling
+- [x] `NotifyRemove()` cancels timers owned by the removed node
+- [x] Render model schedules timers via `tea.Tick` and runs callbacks in `Update`
+- [x] Test: timeout fires when due
+- [x] Test: cleared timeout does not fire
+- [x] Test: interval fires until cleared
+- [x] Test: timers cancel on node removal
+- [x] Test: max duration and max concurrent limits are enforced
 
 ---
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -225,7 +225,7 @@ $('results').render(
 ```
 
 ### Sandboxing
-goja is configured with no I/O primitives: no `require`, no `fetch`, no filesystem, no timers (the runtime provides `on_tick` as a hook instead). Scripts can read/write the DOM, keep local state, and `emit`. The only door to the outside world is `emit('agent', ...)`.
+goja is configured with no I/O primitives: no `require`, no `fetch`, and no filesystem access. The runtime does provide sandboxed `setTimeout`/`setInterval` timers for short-lived local UI behavior; delays above the runtime cap are rejected, concurrent timers are capped, and timers are canceled when their owning node is removed. Scripts can read/write the DOM, keep local state, and `emit`. The only door to the outside world is `emit('agent', ...)`.
 
 ## Widget library
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -749,6 +749,10 @@ func scriptingCatalog() *scriptingInfo {
 			{Name: "state", Description: "Per-node persistent JavaScript object — survives across hook invocations"},
 			{Name: "event", Description: "The hook payload object (e.g., key info for on_key, value for on_change). Only defined during hook execution."},
 			{Name: "debug(...args)", Description: "Log to the server's debug output (not visible in TUI)"},
+			{Name: "setTimeout(fn, delayMs)", Description: "Schedule a one-shot callback owned by the current node. Delays above the runtime cap are rejected."},
+			{Name: "setInterval(fn, delayMs)", Description: "Schedule a repeating callback owned by the current node. Use clearInterval(id) to stop it."},
+			{Name: "clearTimeout(id)", Description: "Cancel a pending timeout by timer ID"},
+			{Name: "clearInterval(id)", Description: "Cancel a pending interval by timer ID"},
 		},
 		Computed: computedInfo{
 			Description: "Computed props are reactive expressions that auto-update when dependencies change. Declare them in the node's computed map. Dependencies are tracked automatically via $ access.",
@@ -756,7 +760,7 @@ func scriptingCatalog() *scriptingInfo {
 		},
 		Sandbox: sandboxInfo{
 			Description: "Scripts run in a locked-down ES5.1 sandbox. The only way to affect the outside world is via emit().",
-			Blocked:     []string{"require", "fetch", "XMLHttpRequest", "setTimeout", "setInterval", "console.log", "console.warn", "console.error"},
+			Blocked:     []string{"require", "fetch", "XMLHttpRequest", "setImmediate", "console.log", "console.warn", "console.error"},
 		},
 		Examples: []example{
 			{

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -1770,7 +1770,7 @@ func TestDescribeScripting_ReturnsGlobals(t *testing.T) {
 	result := callHandlerDirect(t, s, "describe_scripting", map[string]any{})
 	text := resultText(t, result)
 
-	for _, global := range []string{"emit", "state", "event", "debug"} {
+	for _, global := range []string{"emit", "state", "event", "debug", "setTimeout", "setInterval", "clearTimeout", "clearInterval"} {
 		if !strings.Contains(text, global) {
 			t.Errorf("missing global %q in describe_scripting response", global)
 		}

--- a/internal/render/messages.go
+++ b/internal/render/messages.go
@@ -1,5 +1,7 @@
 package render
 
+import "time"
+
 // DOMChangedMsg is sent to the BubbleTea program when the DOM tree has been
 // mutated by an MCP tool call (patch, replace, restore). The Update loop
 // re-syncs the widget tree and re-renders.
@@ -18,3 +20,8 @@ type MCPConnectedMsg struct {
 
 // ShutdownMsg requests a graceful shutdown.
 type ShutdownMsg struct{}
+
+type scriptTimerMsg struct {
+	Seq     uint64
+	FiredAt time.Time
+}

--- a/internal/render/model.go
+++ b/internal/render/model.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"log/slog"
 	"strings"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -29,6 +30,7 @@ type Model struct {
 	scripts             *script.Runtime
 	scriptTree          *dom.Tree
 	knownNodes          map[string]bool
+	timerSeq            uint64
 }
 
 // NewModel creates a new render Model backed by the given MCP server and widget registry.
@@ -66,7 +68,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.width = msg.Width
 		m.height = msg.Height
 		m.syncState()
-		return m, nil
+		cmd := m.withTimerCmd(nil)
+		return m, cmd
 
 	case tea.KeyMsg:
 		m.logger.Info("key", "type", msg.Type, "runes", string(msg.Runes),
@@ -78,7 +81,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, tea.Quit
 			}
 		}
-		return m.handleKey(msg)
+		next, cmd := m.handleKey(msg)
+		return next, cmd
 
 	case DOMChangedMsg:
 		m.logger.Info("DOM changed, syncing state")
@@ -96,7 +100,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.focusedID = m.focus.IDs[0]
 			m.logger.Info("auto-focus first element", "focused", m.focusedID)
 		}
-		return m, nil
+		cmd := m.withTimerCmd(nil)
+		return m, cmd
 
 	case MCPDisconnectedMsg:
 		if msg.SessionID != 0 && msg.SessionID != m.activeSessionID {
@@ -106,7 +111,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.logger.Info("MCP disconnected", "session_id", msg.SessionID, "error", msg.Err)
 		m.activeSessionID = 0
 		m.waitingForReconnect = true
-		return m, nil
+		cmd := m.withTimerCmd(nil)
+		return m, cmd
 
 	case MCPConnectedMsg:
 		m.logger.Info("MCP connected", "session_id", msg.SessionID)
@@ -116,11 +122,29 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.logger.Error("script sync failed", "error", err)
 			m.syncState()
 		}
-		return m, nil
+		cmd := m.withTimerCmd(nil)
+		return m, cmd
 
 	case ShutdownMsg:
 		m.server.Shutdown()
 		return m, tea.Quit
+
+	case scriptTimerMsg:
+		if msg.Seq != m.timerSeq || m.scripts == nil {
+			return m, nil
+		}
+		ran, err := m.scripts.RunDueTimers(msg.FiredAt)
+		if err != nil {
+			m.logger.Error("script timer failed", "error", err)
+		}
+		if ran {
+			if err := m.refreshScriptsAndWidgets(); err != nil {
+				m.logger.Error("script refresh failed", "error", err)
+				m.syncState()
+			}
+		}
+		cmd := m.withTimerCmd(nil)
+		return m, cmd
 	}
 
 	return m, nil
@@ -166,7 +190,7 @@ func (m *Model) syncState() {
 
 // handleKey processes keyboard input. Must be called under the server's Lock
 // (held by Update).
-func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+func (m Model) handleKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 	switch msg.Type {
 	case tea.KeyCtrlC:
 		m.server.Shutdown()
@@ -177,21 +201,26 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.focusedID = m.focusTab(true)
 		m.logger.Info("tab focus", "new_focus", m.focusedID)
 		m.runFocusHooks(oldFocus, m.focusedID)
-		return m, nil
+		cmd := m.withTimerCmd(nil)
+		return m, cmd
 
 	case tea.KeyShiftTab:
 		oldFocus := m.focusedID
 		m.focusedID = m.focusTab(false)
 		m.logger.Info("shift-tab focus", "new_focus", m.focusedID)
 		m.runFocusHooks(oldFocus, m.focusedID)
-		return m, nil
+		cmd := m.withTimerCmd(nil)
+		return m, cmd
 
 	default:
 		// Route to focused widget.
 		if m.focusedID != "" {
-			return m.routeKeyToWidget(msg)
+			next, cmd := m.routeKeyToWidget(msg)
+			timerCmd := next.withTimerCmd(cmd)
+			return next, timerCmd
 		}
-		return m, nil
+		cmd := m.withTimerCmd(nil)
+		return m, cmd
 	}
 }
 
@@ -206,7 +235,7 @@ func (m *Model) focusTab(forward bool) string {
 
 // routeKeyToWidget sends a key message to the currently focused widget and
 // processes any events it produces.
-func (m Model) routeKeyToWidget(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+func (m Model) routeKeyToWidget(msg tea.KeyMsg) (Model, tea.Cmd) {
 	w := m.widgets.Get(m.focusedID)
 	if w == nil {
 		return m, nil
@@ -240,6 +269,44 @@ func (m Model) routeKeyToWidget(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	return m, nil
+}
+
+func (m *Model) withTimerCmd(cmd tea.Cmd) tea.Cmd {
+	timerCmd := m.scheduleTimerCmd()
+	switch {
+	case cmd == nil:
+		return timerCmd
+	case timerCmd == nil:
+		return cmd
+	default:
+		return tea.Batch(cmd, timerCmd)
+	}
+}
+
+func (m *Model) scheduleTimerCmd() tea.Cmd {
+	m.timerSeq++
+	seq := m.timerSeq
+
+	if m.scripts == nil {
+		return nil
+	}
+
+	nextAt, ok := m.scripts.NextTimerAt()
+	if !ok {
+		return nil
+	}
+
+	delay := time.Until(nextAt)
+	if delay < 0 {
+		delay = 0
+	}
+
+	return tea.Tick(delay, func(firedAt time.Time) tea.Msg {
+		return scriptTimerMsg{
+			Seq:     seq,
+			FiredAt: firedAt,
+		}
+	})
 }
 
 // routeWidgetEvent routes a widget event to the appropriate destination:

--- a/internal/render/script_live_test.go
+++ b/internal/render/script_live_test.go
@@ -159,3 +159,106 @@ func TestRenderRunsOnKeyScriptsWithoutButtonClickFallback(t *testing.T) {
 		t.Errorf("expected no fallback click event, got: %s", text)
 	}
 }
+
+func TestRenderRunsTimerCallbacksViaTick(t *testing.T) {
+	srv, err := imcp.NewServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Shutdown()
+
+	m := NewModel(srv, widget.DefaultRegistry())
+	m.width = 80
+	m.height = 24
+
+	callTool(t, srv, "replace", map[string]any{
+		"tree": map[string]any{
+			"id":      "root",
+			"type":    "container",
+			"scripts": map[string]any{"on_mount": "setTimeout(function() { $('status').text = 'done'; }, 1)"},
+			"children": []any{
+				map[string]any{
+					"id":    "status",
+					"type":  "text",
+					"props": map[string]any{"text": "idle"},
+				},
+			},
+		},
+	})
+
+	newM, cmd := m.Update(DOMChangedMsg{})
+	if cmd == nil {
+		t.Fatal("expected DOMChangedMsg to schedule a timer tick")
+	}
+
+	timerMsg := cmd()
+	if _, ok := timerMsg.(scriptTimerMsg); !ok {
+		t.Fatalf("expected scriptTimerMsg, got %T", timerMsg)
+	}
+
+	model := newM.(Model)
+	newM2, _ := model.Update(timerMsg)
+	view := newM2.(Model).View()
+	if !strings.Contains(view, "done") {
+		t.Errorf("timer callback did not update view, got:\n%s", view)
+	}
+}
+
+func TestRenderCancelsTimersWhenOwnerNodeRemoved(t *testing.T) {
+	srv, err := imcp.NewServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Shutdown()
+
+	m := NewModel(srv, widget.DefaultRegistry())
+	m.width = 80
+	m.height = 24
+
+	callTool(t, srv, "replace", map[string]any{
+		"tree": map[string]any{
+			"id":   "root",
+			"type": "container",
+			"children": []any{
+				map[string]any{
+					"id":    "status",
+					"type":  "text",
+					"props": map[string]any{"text": "idle"},
+				},
+				map[string]any{
+					"id":      "countdown",
+					"type":    "text",
+					"scripts": map[string]any{"on_mount": "setTimeout(function() { $('status').text = 'boom'; }, 10)"},
+				},
+			},
+		},
+	})
+
+	newM, cmd := m.Update(DOMChangedMsg{})
+	if cmd == nil {
+		t.Fatal("expected DOMChangedMsg to schedule a timer tick")
+	}
+	model := newM.(Model)
+
+	callTool(t, srv, "patch", map[string]any{
+		"ops": []map[string]any{
+			{
+				"op": "remove",
+				"id": "countdown",
+			},
+		},
+	})
+
+	newM2, _ := model.Update(DOMChangedMsg{})
+	model2 := newM2.(Model)
+
+	timerMsg := cmd()
+	newM3, _ := model2.Update(timerMsg)
+	view := newM3.(Model).View()
+	if strings.Contains(view, "boom") {
+		t.Errorf("removed node timer should not have fired, got:\n%s", view)
+	}
+	if !strings.Contains(view, "idle") {
+		t.Errorf("expected status to remain idle, got:\n%s", view)
+	}
+}

--- a/internal/script/hooks.go
+++ b/internal/script/hooks.go
@@ -61,6 +61,7 @@ func (rt *Runtime) NotifyMount(nodeID string) error {
 func (rt *Runtime) NotifyRemove(nodeID string) {
 	rt.removeState(nodeID)
 	rt.mu.Lock()
+	rt.clearNodeTimersLocked(nodeID)
 	rt.deps.RemoveNode(nodeID)
 	rt.mu.Unlock()
 }

--- a/internal/script/runtime.go
+++ b/internal/script/runtime.go
@@ -16,16 +16,21 @@ const defaultTimeout = 10 * time.Millisecond
 // Runtime is the script execution engine for a session.
 // It owns a single goja VM and manages per-node state.
 type Runtime struct {
-	mu          sync.Mutex
-	vm          *goja.Runtime
-	tree        *dom.Tree
-	events      *dom.EventQueue
-	states      map[string]*goja.Object // nodeID -> persistent JS state
-	deps        *DepGraph               // computed prop dependency tracking
-	dirty       map[string]bool         // nodes modified since last propagation
-	currentEval *evalCtx                // non-nil during computed prop eval
-	timeout     time.Duration
-	debugLog    func(string)
+	mu                  sync.Mutex
+	vm                  *goja.Runtime
+	tree                *dom.Tree
+	events              *dom.EventQueue
+	states              map[string]*goja.Object // nodeID -> persistent JS state
+	deps                *DepGraph               // computed prop dependency tracking
+	dirty               map[string]bool         // nodes modified since last propagation
+	currentEval         *evalCtx                // non-nil during computed prop eval
+	timeout             time.Duration
+	debugLog            func(string)
+	timers              map[int64]*scriptTimer
+	timerOwners         map[string]map[int64]bool
+	nextTimerID         int64
+	maxTimerDuration    time.Duration
+	maxConcurrentTimers int
 }
 
 // Option configures the Runtime.
@@ -45,16 +50,32 @@ func WithDebugLog(fn func(string)) Option {
 	}
 }
 
+// WithTimerLimits configures the runtime's timer safety limits.
+func WithTimerLimits(maxDuration time.Duration, maxConcurrent int) Option {
+	return func(rt *Runtime) {
+		if maxDuration > 0 {
+			rt.maxTimerDuration = maxDuration
+		}
+		if maxConcurrent > 0 {
+			rt.maxConcurrentTimers = maxConcurrent
+		}
+	}
+}
+
 // New creates a new script Runtime bound to a DOM tree and event queue.
 func New(tree *dom.Tree, events *dom.EventQueue, opts ...Option) *Runtime {
 	rt := &Runtime{
-		vm:      goja.New(),
-		tree:    tree,
-		events:  events,
-		states:  make(map[string]*goja.Object),
-		deps:    newDepGraph(),
-		dirty:   make(map[string]bool),
-		timeout: defaultTimeout,
+		vm:                  goja.New(),
+		tree:                tree,
+		events:              events,
+		states:              make(map[string]*goja.Object),
+		deps:                newDepGraph(),
+		dirty:               make(map[string]bool),
+		timeout:             defaultTimeout,
+		timers:              make(map[int64]*scriptTimer),
+		timerOwners:         map[string]map[int64]bool{},
+		maxTimerDuration:    defaultMaxTimerDuration,
+		maxConcurrentTimers: defaultMaxConcurrentTimers,
 	}
 	for _, opt := range opts {
 		opt(rt)
@@ -68,8 +89,8 @@ func (rt *Runtime) initSandbox() {
 	// Delete dangerous globals by setting them to undefined.
 	dangerous := []string{
 		"require", "importScripts",
-		"setTimeout", "setInterval", "setImmediate",
-		"clearTimeout", "clearInterval", "clearImmediate",
+		"setImmediate",
+		"clearImmediate",
 		"fetch", "XMLHttpRequest",
 		"process", "globalThis",
 	}
@@ -168,6 +189,12 @@ func (rt *Runtime) setupContext(node *dom.Node, payload *HookPayload) {
 
 	// Bind emit function.
 	_ = rt.vm.Set("emit", rt.makeEmitFn(node.ID))
+
+	// Bind timer functions.
+	_ = rt.vm.Set("setTimeout", rt.makeSetTimerFn(node.ID, false))
+	_ = rt.vm.Set("setInterval", rt.makeSetTimerFn(node.ID, true))
+	_ = rt.vm.Set("clearTimeout", rt.makeClearTimerFn())
+	_ = rt.vm.Set("clearInterval", rt.makeClearTimerFn())
 
 	// Bind event payload if present.
 	if payload != nil {

--- a/internal/script/sandbox_test.go
+++ b/internal/script/sandbox_test.go
@@ -34,11 +34,7 @@ func TestForbiddenAPIs(t *testing.T) {
 	}{
 		{"require", `require('fs')`},
 		{"fetch", `fetch('http://example.com')`},
-		{"setTimeout", `setTimeout(function(){}, 100)`},
-		{"setInterval", `setInterval(function(){}, 100)`},
 		{"setImmediate", `setImmediate(function(){})`},
-		{"clearTimeout", `clearTimeout(1)`},
-		{"clearInterval", `clearInterval(1)`},
 		{"process", `process.exit(1)`},
 	}
 
@@ -53,6 +49,28 @@ func TestForbiddenAPIs(t *testing.T) {
 				t.Errorf("expected script.Error, got %T: %v", err, err)
 			}
 		})
+	}
+}
+
+func TestTimerGlobalsAvailable(t *testing.T) {
+	rt := newTestRuntime(t)
+
+	err := rt.execScript("root", "test", `
+		if (typeof setTimeout !== "function") {
+			throw new Error("expected setTimeout to be available");
+		}
+		if (typeof setInterval !== "function") {
+			throw new Error("expected setInterval to be available");
+		}
+		if (typeof clearTimeout !== "function") {
+			throw new Error("expected clearTimeout to be available");
+		}
+		if (typeof clearInterval !== "function") {
+			throw new Error("expected clearInterval to be available");
+		}
+	`, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/internal/script/timer.go
+++ b/internal/script/timer.go
@@ -1,0 +1,244 @@
+package script
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/dop251/goja"
+)
+
+const (
+	defaultMaxTimerDuration    = 5 * time.Second
+	defaultMaxConcurrentTimers = 32
+)
+
+type scriptTimer struct {
+	id          int64
+	ownerNodeID string
+	callback    goja.Callable
+	args        []goja.Value
+	interval    time.Duration
+	nextFire    time.Time
+	repeat      bool
+}
+
+// NextTimerAt returns the next scheduled timer fire time, if any.
+func (rt *Runtime) NextTimerAt() (time.Time, bool) {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+
+	return rt.nextTimerAtLocked()
+}
+
+func (rt *Runtime) nextTimerAtLocked() (time.Time, bool) {
+	var next time.Time
+	var ok bool
+	for _, timer := range rt.timers {
+		if !ok || timer.nextFire.Before(next) {
+			next = timer.nextFire
+			ok = true
+		}
+	}
+	return next, ok
+}
+
+// RunDueTimers executes all timers whose due time is at or before now.
+// Timer callbacks run in the same serialized VM context as hooks.
+func (rt *Runtime) RunDueTimers(now time.Time) (bool, error) {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+
+	due := rt.dueTimerIDsLocked(now)
+	if len(due) == 0 {
+		return false, nil
+	}
+
+	rt.dirty = make(map[string]bool)
+
+	ran := false
+	var firstErr error
+	for _, id := range due {
+		timer, ok := rt.timers[id]
+		if !ok || timer.nextFire.After(now) {
+			continue
+		}
+
+		node := rt.tree.Find(timer.ownerNodeID)
+		if node == nil {
+			rt.clearTimerLocked(id)
+			continue
+		}
+
+		if timer.repeat {
+			timer.nextFire = now.Add(timer.interval)
+		} else {
+			rt.clearTimerLocked(id)
+		}
+
+		rt.setupContext(node, nil)
+
+		timeout := rt.startTimeout()
+		_, err := timer.callback(goja.Undefined(), timer.args...)
+		rt.stopTimeout(timeout)
+		if err != nil {
+			rt.clearTimerLocked(id)
+			if firstErr == nil {
+				firstErr = wrapTimerError(timer.ownerNodeID, err)
+			}
+			continue
+		}
+
+		ran = true
+	}
+
+	return ran, firstErr
+}
+
+func (rt *Runtime) dueTimerIDsLocked(now time.Time) []int64 {
+	type dueTimer struct {
+		id       int64
+		nextFire time.Time
+	}
+
+	due := make([]dueTimer, 0, len(rt.timers))
+	for id, timer := range rt.timers {
+		if timer.nextFire.After(now) {
+			continue
+		}
+		due = append(due, dueTimer{id: id, nextFire: timer.nextFire})
+	}
+
+	sort.Slice(due, func(i, j int) bool {
+		if due[i].nextFire.Equal(due[j].nextFire) {
+			return due[i].id < due[j].id
+		}
+		return due[i].nextFire.Before(due[j].nextFire)
+	})
+
+	ids := make([]int64, 0, len(due))
+	for _, item := range due {
+		ids = append(ids, item.id)
+	}
+	return ids
+}
+
+func (rt *Runtime) makeSetTimerFn(ownerNodeID string, repeat bool) func(goja.FunctionCall) goja.Value {
+	return func(call goja.FunctionCall) goja.Value {
+		id, err := rt.registerTimerLocked(ownerNodeID, call, repeat)
+		if err != nil {
+			panic(rt.vm.NewTypeError(err.Error()))
+		}
+		return rt.vm.ToValue(id)
+	}
+}
+
+func (rt *Runtime) makeClearTimerFn() func(goja.FunctionCall) goja.Value {
+	return func(call goja.FunctionCall) goja.Value {
+		if len(call.Arguments) == 0 || goja.IsUndefined(call.Arguments[0]) || goja.IsNull(call.Arguments[0]) {
+			return goja.Undefined()
+		}
+		rt.clearTimerLocked(call.Arguments[0].ToInteger())
+		return goja.Undefined()
+	}
+}
+
+func (rt *Runtime) registerTimerLocked(ownerNodeID string, call goja.FunctionCall, repeat bool) (int64, error) {
+	name := "setTimeout"
+	if repeat {
+		name = "setInterval"
+	}
+	if len(call.Arguments) == 0 {
+		return 0, fmt.Errorf("%s requires a callback", name)
+	}
+
+	callback, ok := goja.AssertFunction(call.Arguments[0])
+	if !ok {
+		return 0, fmt.Errorf("%s requires a function callback", name)
+	}
+	if len(rt.timers) >= rt.maxConcurrentTimers {
+		return 0, fmt.Errorf("max concurrent timers is %d", rt.maxConcurrentTimers)
+	}
+
+	delay, err := rt.parseTimerDelay(call.Argument(1))
+	if err != nil {
+		return 0, err
+	}
+
+	rt.nextTimerID++
+	id := rt.nextTimerID
+	timer := &scriptTimer{
+		id:          id,
+		ownerNodeID: ownerNodeID,
+		callback:    callback,
+		args:        append([]goja.Value(nil), call.Arguments[2:]...),
+		interval:    delay,
+		nextFire:    time.Now().Add(delay),
+		repeat:      repeat,
+	}
+
+	rt.timers[id] = timer
+	if rt.timerOwners[ownerNodeID] == nil {
+		rt.timerOwners[ownerNodeID] = make(map[int64]bool)
+	}
+	rt.timerOwners[ownerNodeID][id] = true
+
+	return id, nil
+}
+
+func (rt *Runtime) parseTimerDelay(value goja.Value) (time.Duration, error) {
+	if value == nil || goja.IsUndefined(value) || goja.IsNull(value) {
+		return 0, nil
+	}
+
+	ms := value.ToInteger()
+	if ms < 0 {
+		ms = 0
+	}
+	maxMs := int64(rt.maxTimerDuration / time.Millisecond)
+	if ms > maxMs {
+		return 0, fmt.Errorf("max timer duration is %s", rt.maxTimerDuration)
+	}
+	return time.Duration(ms) * time.Millisecond, nil
+}
+
+func (rt *Runtime) clearTimerLocked(id int64) {
+	timer, ok := rt.timers[id]
+	if !ok {
+		return
+	}
+	delete(rt.timers, id)
+
+	owned := rt.timerOwners[timer.ownerNodeID]
+	delete(owned, id)
+	if len(owned) == 0 {
+		delete(rt.timerOwners, timer.ownerNodeID)
+	}
+}
+
+func (rt *Runtime) clearNodeTimersLocked(nodeID string) {
+	owned := rt.timerOwners[nodeID]
+	for id := range owned {
+		delete(rt.timers, id)
+	}
+	delete(rt.timerOwners, nodeID)
+}
+
+func wrapTimerError(nodeID string, err error) error {
+	var interrupted *goja.InterruptedError
+	if errors.As(err, &interrupted) {
+		return &Error{
+			NodeID:    nodeID,
+			Hook:      "timer",
+			Message:   interrupted.String(),
+			IsTimeout: true,
+		}
+	}
+
+	return &Error{
+		NodeID:  nodeID,
+		Hook:    "timer",
+		Message: err.Error(),
+	}
+}

--- a/internal/script/timer_test.go
+++ b/internal/script/timer_test.go
@@ -1,0 +1,175 @@
+package script
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSetTimeoutFiresWhenDue(t *testing.T) {
+	rt := newTestRuntimeWithTree(t)
+
+	if err := rt.execScript("child1", "test", `
+		setTimeout(function() {
+			$.text = "later";
+		}, 10)
+	`, nil); err != nil {
+		t.Fatalf("execScript: %v", err)
+	}
+
+	if ran, err := rt.RunDueTimers(time.Now()); err != nil {
+		t.Fatalf("RunDueTimers before due: %v", err)
+	} else if ran {
+		t.Fatal("expected no timer callback before due")
+	}
+
+	if ran, err := rt.RunDueTimers(time.Now().Add(20 * time.Millisecond)); err != nil {
+		t.Fatalf("RunDueTimers when due: %v", err)
+	} else if !ran {
+		t.Fatal("expected timer callback to run")
+	}
+
+	node := rt.tree.Find("child1")
+	if node == nil {
+		t.Fatal("expected child1 node")
+	}
+	if got, _ := node.GetProp("text"); got != "later" {
+		t.Fatalf("expected text to be updated by timeout, got %v", got)
+	}
+}
+
+func TestClearTimeoutCancelsPendingTimer(t *testing.T) {
+	rt := newTestRuntimeWithTree(t)
+
+	if err := rt.execScript("child1", "test", `
+		var id = setTimeout(function() {
+			$.text = "should-not-run";
+		}, 10);
+		clearTimeout(id);
+	`, nil); err != nil {
+		t.Fatalf("execScript: %v", err)
+	}
+
+	if ran, err := rt.RunDueTimers(time.Now().Add(20 * time.Millisecond)); err != nil {
+		t.Fatalf("RunDueTimers: %v", err)
+	} else if ran {
+		t.Fatal("expected cleared timeout not to run")
+	}
+
+	node := rt.tree.Find("child1")
+	if node == nil {
+		t.Fatal("expected child1 node")
+	}
+	if got, _ := node.GetProp("text"); got != "hello" {
+		t.Fatalf("expected text to remain unchanged, got %v", got)
+	}
+}
+
+func TestSetIntervalFiresUntilCleared(t *testing.T) {
+	rt := newTestRuntimeWithTree(t)
+
+	if err := rt.execScript("child1", "test", `
+		state.count = 0;
+		var id = setInterval(function() {
+			state.count += 1;
+			$.text = "tick:" + state.count;
+			if (state.count === 2) {
+				clearInterval(id);
+			}
+		}, 10);
+	`, nil); err != nil {
+		t.Fatalf("execScript: %v", err)
+	}
+
+	if ran, err := rt.RunDueTimers(time.Now().Add(20 * time.Millisecond)); err != nil {
+		t.Fatalf("first RunDueTimers: %v", err)
+	} else if !ran {
+		t.Fatal("expected first interval callback to run")
+	}
+
+	node := rt.tree.Find("child1")
+	if node == nil {
+		t.Fatal("expected child1 node")
+	}
+	if got, _ := node.GetProp("text"); got != "tick:1" {
+		t.Fatalf("expected first interval update, got %v", got)
+	}
+
+	if ran, err := rt.RunDueTimers(time.Now().Add(40 * time.Millisecond)); err != nil {
+		t.Fatalf("second RunDueTimers: %v", err)
+	} else if !ran {
+		t.Fatal("expected second interval callback to run")
+	}
+
+	if got, _ := node.GetProp("text"); got != "tick:2" {
+		t.Fatalf("expected second interval update, got %v", got)
+	}
+
+	if ran, err := rt.RunDueTimers(time.Now().Add(60 * time.Millisecond)); err != nil {
+		t.Fatalf("third RunDueTimers: %v", err)
+	} else if ran {
+		t.Fatal("expected cleared interval not to run again")
+	}
+}
+
+func TestTimersCancelOnNotifyRemove(t *testing.T) {
+	rt := newTestRuntimeWithTree(t)
+
+	if err := rt.execScript("child1", "test", `
+		setTimeout(function() {
+			$.text = "should-not-run";
+		}, 10)
+	`, nil); err != nil {
+		t.Fatalf("execScript: %v", err)
+	}
+
+	rt.NotifyRemove("child1")
+
+	if ran, err := rt.RunDueTimers(time.Now().Add(20 * time.Millisecond)); err != nil {
+		t.Fatalf("RunDueTimers: %v", err)
+	} else if ran {
+		t.Fatal("expected removed node timers not to run")
+	}
+}
+
+func TestSetTimeoutRejectsOverMaxDuration(t *testing.T) {
+	rt := newTestRuntimeWithTree(t)
+	rt = New(rt.tree, rt.events, WithTimerLimits(25*time.Millisecond, 4))
+
+	err := rt.execScript("child1", "test", `setTimeout(function(){}, 50)`, nil)
+	if err == nil {
+		t.Fatal("expected timer duration error")
+	}
+	var se *Error
+	if !errors.As(err, &se) {
+		t.Fatalf("expected script.Error, got %T: %v", err, err)
+	}
+	if !strings.Contains(se.Message, "max timer duration") {
+		t.Fatalf("expected max timer duration message, got %q", se.Message)
+	}
+}
+
+func TestSetTimeoutRejectsWhenMaxConcurrentTimersExceeded(t *testing.T) {
+	rt := newTestRuntimeWithTree(t)
+	rt = New(rt.tree, rt.events, WithTimerLimits(100*time.Millisecond, 1))
+
+	err := rt.execScript("child1", "test", `
+		setTimeout(function() {}, 10);
+		setTimeout(function() {}, 10);
+	`, nil)
+	if err == nil {
+		t.Fatal("expected max concurrent timer error")
+	}
+	var se *Error
+	if !errors.As(err, &se) {
+		t.Fatalf("expected script.Error, got %T: %v", err, err)
+	}
+	if !strings.Contains(se.Message, "max concurrent timers") {
+		t.Fatalf("expected max concurrent timers message, got %q", se.Message)
+	}
+
+	if len(rt.timers) != 1 {
+		t.Fatalf("expected first timer to remain scheduled, got %d timers", len(rt.timers))
+	}
+}


### PR DESCRIPTION
Add sandboxed setTimeout/setInterval support to the script runtime, including clearTimeout/clearInterval, rejected over-cap delays, concurrent timer limits, and cleanup on node removal.
Wire timers through the Bubble Tea render loop so due callbacks run inside Update via tea.Tick and stale scheduled ticks are ignored safely.
Add unit and integration coverage for timer behavior, update sandbox expectations, and document the new APIs in describe_scripting, SPEC, and SCRIPT_RUNTIME.
Verified with go test ./... and /Users/jdc/go/bin/golangci-lint run.