### PR TITLE
Add container overflow scrolling

### DIFF
--- a/cmd/imagine-tui/agent_demo_e2e_test.go
+++ b/cmd/imagine-tui/agent_demo_e2e_test.go
@@ -82,6 +82,7 @@ func TestAgentBuildsDemoAppOverBridgeAndTUIWorks(t *testing.T) {
 					"props": map[string]any{
 						"auto_scroll": true,
 						"max_lines":   50,
+						"focusable":   false,
 					},
 				},
 			},
@@ -292,6 +293,7 @@ func TestAgentIteratesOnMultiStepDemoScenarioOverBridge(t *testing.T) {
 					"props": map[string]any{
 						"auto_scroll": true,
 						"max_lines":   2,
+						"focusable":   false,
 					},
 				},
 			},

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -144,6 +144,7 @@ Items not tied to a milestone. Will be scheduled as needed.
 - Discovered during live demo: log/narrative panels overflow their containers
 - **Implementation**: wrap container rendering in `viewport.Model` when `overflow: "scroll"` and height is constrained
 - **Runtime note**: overflow-scrolling containers must be keyboard-focusable alongside the existing scrollable widget defaults (`log`, `code`)
+- **Future follow-up**: add a clearer focus-policy API for passive scroll panes so logs/code blocks can opt out of Tab order without relying on the generic `focusable` override
 - **Scope note**: keep scroll position as widget-local runtime state for now; snapshot/query serialization can be handled separately
 - **TDD**: golden file tests for constrained containers, overflow clipping
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -143,6 +143,8 @@ Items not tied to a milestone. Will be scheduled as needed.
 - Without this, tall content pushes the entire screen down instead of scrolling within its panel
 - Discovered during live demo: log/narrative panels overflow their containers
 - **Implementation**: wrap container rendering in `viewport.Model` when `overflow: "scroll"` and height is constrained
+- **Runtime note**: overflow-scrolling containers must be keyboard-focusable alongside the existing scrollable widget defaults (`log`, `code`)
+- **Scope note**: keep scroll position as widget-local runtime state for now; snapshot/query serialization can be handled separately
 - **TDD**: golden file tests for constrained containers, overflow clipping
 
 ### Flex layout & layout managers

--- a/internal/render/focus.go
+++ b/internal/render/focus.go
@@ -11,6 +11,8 @@ var focusableTypes = map[dom.NodeType]bool{
 	dom.TypeTable:    true,
 	dom.TypeList:     true,
 	dom.TypeDiff:     true,
+	dom.TypeLog:      true,
+	dom.TypeCode:     true,
 }
 
 // FocusRing maintains an ordered list of focusable node IDs.
@@ -42,7 +44,22 @@ func isFocusable(n *dom.Node) bool {
 			return b
 		}
 	}
+	if n.Type == dom.TypeContainer && isScrollContainer(n) {
+		return true
+	}
 	return focusableTypes[n.Type]
+}
+
+func isScrollContainer(n *dom.Node) bool {
+	if n.Type != dom.TypeContainer {
+		return false
+	}
+	if overflow, ok := n.GetProp("overflow"); !ok || overflow != "scroll" {
+		return false
+	}
+	_, hasHeight := n.GetProp("height")
+	_, hasMaxHeight := n.GetProp("max_height")
+	return hasHeight || hasMaxHeight
 }
 
 // Contains returns true if the given ID is in the focus ring.

--- a/internal/render/focus_test.go
+++ b/internal/render/focus_test.go
@@ -86,6 +86,7 @@ func TestBuildFocusRingAllTypes(t *testing.T) {
 	for i, typ := range []dom.NodeType{
 		dom.TypeInput, dom.TypeTextarea, dom.TypeSelect,
 		dom.TypeButton, dom.TypeTable, dom.TypeList, dom.TypeDiff,
+		dom.TypeLog, dom.TypeCode,
 	} {
 		id := "n" + string(rune('0'+i))
 		n, _ := dom.NewNode(id, typ)
@@ -93,8 +94,26 @@ func TestBuildFocusRingAllTypes(t *testing.T) {
 	}
 
 	ring := BuildFocusRing(tree)
-	if len(ring.IDs) != 7 {
-		t.Fatalf("expected 7 focusable nodes, got %d: %v", len(ring.IDs), ring.IDs)
+	if len(ring.IDs) != 9 {
+		t.Fatalf("expected 9 focusable nodes, got %d: %v", len(ring.IDs), ring.IDs)
+	}
+}
+
+func TestBuildFocusRingIncludesOverflowScrollContainer(t *testing.T) {
+	root, _ := dom.NewNode("root", dom.TypeContainer)
+	tree, _ := dom.NewTree(root)
+
+	panel, _ := dom.NewNode("panel", dom.TypeContainer)
+	panel.SetProp("overflow", "scroll")
+	panel.SetProp("height", 5)
+	mustInsert(t, tree, "root", panel)
+
+	body, _ := dom.NewNode("body", dom.TypeText)
+	mustInsert(t, tree, "panel", body)
+
+	ring := BuildFocusRing(tree)
+	if !ring.Contains("panel") {
+		t.Fatalf("expected overflow-scrolling container to be focusable, got %v", ring.IDs)
 	}
 }
 

--- a/internal/render/model_test.go
+++ b/internal/render/model_test.go
@@ -162,6 +162,50 @@ func TestModelKeyRouteToFocusedWidget(t *testing.T) {
 	}
 }
 
+func TestModelKeyRouteToFocusedScrollContainer(t *testing.T) {
+	srv, err := imcp.NewServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	root := srv.Tree().Root
+	root.SetProp("direction", "vertical")
+
+	panel, _ := dom.NewNode("panel", dom.TypeContainer)
+	panel.SetProp("overflow", "scroll")
+	panel.SetProp("height", 3)
+	panel.SetProp("focusable", true)
+	if err := srv.Tree().Insert("root", panel, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	body, _ := dom.NewNode("body", dom.TypeText)
+	body.SetProp("wrap", false)
+	body.SetProp("text", "line1\nline2\nline3\nline4\nline5")
+	if err := srv.Tree().Insert("panel", body, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	m := NewModel(srv, widget.DefaultRegistry())
+	m.width = 40
+	m.height = 10
+	m.syncState()
+	m.focusedID = "panel"
+
+	before := m.View()
+	if !strings.Contains(before, "line1") {
+		t.Fatalf("expected initial viewport content, got:\n%s", before)
+	}
+
+	newM, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	model := newM.(Model)
+
+	after := model.View()
+	if !strings.Contains(after, "line4") || strings.Contains(after, "line1") {
+		t.Fatalf("expected scrolled viewport, got:\n%s", after)
+	}
+}
+
 // --- M5-4 Tests ---
 
 func TestModelWindowSizeMsg(t *testing.T) {

--- a/internal/widget/catalog.go
+++ b/internal/widget/catalog.go
@@ -30,19 +30,22 @@ func Catalog() []Info {
 	return []Info{
 		{
 			Type:        "container",
-			Description: "Layout container that arranges children horizontally or vertically. Use as the structural backbone of any UI.",
+			Description: "Layout container that arranges children horizontally or vertically. Use as the structural backbone of any UI. When overflow is set to \"scroll\" and height is constrained, the container becomes keyboard-scrollable.",
 			Props: []PropInfo{
 				{Name: "direction", Type: "string", Description: "Layout direction: \"horizontal\" or \"vertical\"", Default: "vertical"},
 				{Name: "gap", Type: "int", Description: "Spacing between children in cells"},
 				{Name: "padding", Type: "int", Description: "Inner padding in cells"},
 				{Name: "border", Type: "string", Description: "Border style: \"none\", \"rounded\", \"thick\", \"double\", \"hidden\"", Default: "none"},
 				{Name: "width", Type: "string", Description: "Width: integer (fixed), \"50%\" (percent), or \"fill\" (remaining space)"},
+				{Name: "height", Type: "string", Description: "Height: integer (fixed) or \"50%\" of the available parent height"},
+				{Name: "max_height", Type: "string", Description: "Maximum height: integer (fixed) or \"50%\" of the available parent height"},
+				{Name: "overflow", Type: "string", Description: "Overflow behavior. Set to \"scroll\" to enable a viewport when height is constrained"},
 				{Name: "style", Type: "string", Description: "Theme token for styling"},
 				{Name: "focus_trap", Type: "bool", Description: "If true, Tab/Shift-Tab cycles only among focusable descendants"},
 				{Name: "item_template", Type: "map", Description: "Template for set_items: a node spec with {{key}} placeholders in string props"},
 			},
 			Focusable:  false,
-			Scrollable: false,
+			Scrollable: true,
 		},
 		{
 			Type:        "text",

--- a/internal/widget/container.go
+++ b/internal/widget/container.go
@@ -4,20 +4,52 @@ import (
 	"strconv"
 	"strings"
 
+	bviewport "github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/joncooper/imagine-tui/internal/dom"
 )
 
 // ContainerWidget implements flex-like layout with vertical/horizontal direction.
-type ContainerWidget struct{}
+type ContainerWidget struct {
+	vp      bviewport.Model
+	vpReady bool
+}
 
 // Init implements Widget.
-func (w *ContainerWidget) Init(_ *dom.Node) {}
+func (w *ContainerWidget) Init(_ *dom.Node) {
+	w.vp = bviewport.New(0, 0)
+}
 
 // Update implements Widget.
-func (w *ContainerWidget) Update(_ tea.Msg, _ *dom.Node) UpdateResult {
-	return UpdateResult{}
+func (w *ContainerWidget) Update(msg tea.Msg, node *dom.Node) UpdateResult {
+	if !w.vpReady || PropString(node, "overflow", "") != "scroll" {
+		return UpdateResult{}
+	}
+
+	keyMsg, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return UpdateResult{}
+	}
+
+	switch keyMsg.Type {
+	case tea.KeyDown:
+		w.vp.ScrollDown(1)
+	case tea.KeyUp:
+		w.vp.ScrollUp(1)
+	case tea.KeyPgDown:
+		w.vp.PageDown()
+	case tea.KeyPgUp:
+		w.vp.PageUp()
+	case tea.KeyHome:
+		w.vp.GotoTop()
+	case tea.KeyEnd:
+		w.vp.GotoBottom()
+	default:
+		return UpdateResult{}
+	}
+
+	return UpdateResult{Consumed: true}
 }
 
 // Layout implements Widget.
@@ -181,10 +213,86 @@ func (w *ContainerWidget) View(node *dom.Node, children []RenderedChild, ctx Vie
 		style = mergeStyles(style, tokenStyle)
 	}
 
+	height, hasHeight := PropSize(node, "height", ctx.Height)
+	maxHeight, hasMaxHeight := PropSize(node, "max_height", ctx.Height)
+	if hasHeight {
+		style = style.Height(height)
+	}
+	if hasMaxHeight && !hasHeight {
+		style = style.MaxHeight(maxHeight)
+	}
+
+	if PropString(node, "overflow", "") == "scroll" {
+		if inner, ok := w.viewportContent(node, composed, ctx.Width, height, hasHeight, maxHeight, hasMaxHeight); ok {
+			composed = inner
+		}
+	} else {
+		w.vpReady = false
+	}
+
 	if composed == "" {
 		return style.Render("")
 	}
 	return style.Render(composed)
+}
+
+func (w *ContainerWidget) viewportContent(node *dom.Node, composed string, width, height int, hasHeight bool, maxHeight int, hasMaxHeight bool) (string, bool) {
+	padding := PropInt(node, "padding", 0)
+	borderName := PropString(node, "border", "none")
+
+	var outerHeight int
+	switch {
+	case hasHeight:
+		outerHeight = height
+	case hasMaxHeight:
+		outerHeight = maxHeight
+	default:
+		w.vpReady = false
+		return "", false
+	}
+
+	innerWidth := width - 2*padding - borderWidth(borderName)
+	innerHeight := outerHeight - 2*padding - borderHeight(borderName)
+	if innerWidth <= 0 || innerHeight <= 0 {
+		w.vpReady = false
+		return "", false
+	}
+
+	attachViewport := hasHeight
+	if !attachViewport && hasMaxHeight {
+		attachViewport = lineCount(composed) > innerHeight
+	}
+	if !attachViewport {
+		w.vpReady = false
+		return "", false
+	}
+
+	w.vp.Width = innerWidth
+	w.vp.Height = innerHeight
+	w.vp.SetContent(composed)
+	clampViewport(&w.vp)
+	w.vpReady = true
+	return w.vp.View(), true
+}
+
+func lineCount(s string) int {
+	if s == "" {
+		return 0
+	}
+	return strings.Count(s, "\n") + 1
+}
+
+func clampViewport(vp *bviewport.Model) {
+	maxOffset := vp.TotalLineCount() - vp.Height
+	if maxOffset < 0 {
+		maxOffset = 0
+	}
+	if vp.YOffset > maxOffset {
+		vp.SetYOffset(maxOffset)
+	}
+	if vp.YOffset < 0 {
+		vp.SetYOffset(0)
+	}
 }
 
 func joinHorizontal(views []string, gap int) string {

--- a/internal/widget/container_test.go
+++ b/internal/widget/container_test.go
@@ -4,7 +4,9 @@ import (
 	"strings"
 	"testing"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/joncooper/imagine-tui/internal/dom"
+	"github.com/joncooper/imagine-tui/internal/testutil"
 )
 
 func containerNode(t *testing.T, props map[string]any) *dom.Node {
@@ -257,6 +259,55 @@ func TestContainerView_Empty(t *testing.T) {
 	// Empty container should render something (possibly empty string).
 	// Just verify it doesn't panic.
 	_ = got
+}
+
+func TestContainerView_OverflowScroll_ClipsToHeight(t *testing.T) {
+	w := &ContainerWidget{}
+	n := containerNode(t, map[string]any{
+		"direction": "vertical",
+		"height":    3,
+		"overflow":  "scroll",
+	})
+
+	children := []RenderedChild{
+		{NodeID: "c1", View: "line1\nline2\nline3\nline4\nline5"},
+	}
+	ctx := ViewContext{Width: 5, Height: 10, Theme: DefaultTheme()}
+
+	got := w.View(n, children, ctx)
+
+	if strings.Contains(got, "line4") || strings.Contains(got, "line5") {
+		t.Fatalf("expected clipped output, got:\n%s", got)
+	}
+
+	testutil.GoldenFile(t, "widget/container_overflow_initial.golden", []byte(got+"\n"))
+}
+
+func TestContainerUpdate_OverflowScroll_ScrollsViewport(t *testing.T) {
+	w := &ContainerWidget{}
+	n := containerNode(t, map[string]any{
+		"direction": "vertical",
+		"height":    3,
+		"overflow":  "scroll",
+	})
+
+	children := []RenderedChild{
+		{NodeID: "c1", View: "line1\nline2\nline3\nline4\nline5"},
+	}
+	ctx := ViewContext{Width: 5, Height: 10, Theme: DefaultTheme()}
+
+	_ = w.View(n, children, ctx)
+	result := w.Update(tea.KeyMsg{Type: tea.KeyDown}, n)
+	if !result.Consumed {
+		t.Fatal("expected scroll key to be consumed")
+	}
+
+	got := w.View(n, children, ctx)
+	if !strings.Contains(got, "line4") || strings.Contains(got, "line1") {
+		t.Fatalf("expected viewport to scroll, got:\n%s", got)
+	}
+
+	testutil.GoldenFile(t, "widget/container_overflow_scrolled.golden", []byte(got+"\n"))
 }
 
 func TestContainerLayout_WithBorder_ReducesAvailable(t *testing.T) {

--- a/internal/widget/props.go
+++ b/internal/widget/props.go
@@ -1,6 +1,9 @@
 package widget
 
 import (
+	"strconv"
+	"strings"
+
 	"github.com/joncooper/imagine-tui/internal/dom"
 )
 
@@ -91,4 +94,44 @@ func PropMapSlice(node *dom.Node, key string) []map[string]any {
 func stringFromMap(m map[string]any, key string) string {
 	v, _ := m[key].(string)
 	return v
+}
+
+// PropSize resolves an integer or percentage-valued prop against available.
+// Returns false when the prop is missing, invalid, or cannot be resolved.
+func PropSize(node *dom.Node, key string, available int) (int, bool) {
+	v, ok := node.GetProp(key)
+	if !ok {
+		return 0, false
+	}
+	return ResolveSize(v, available)
+}
+
+// ResolveSize resolves an absolute or percentage value against available.
+func ResolveSize(v any, available int) (int, bool) {
+	switch val := v.(type) {
+	case int:
+		if val < 0 {
+			return 0, true
+		}
+		return val, true
+	case float64:
+		if val < 0 {
+			return 0, true
+		}
+		return int(val), true
+	case string:
+		if !strings.HasSuffix(val, "%") || available <= 0 {
+			return 0, false
+		}
+		pct, err := strconv.Atoi(strings.TrimSuffix(val, "%"))
+		if err != nil {
+			return 0, false
+		}
+		if pct < 0 {
+			pct = 0
+		}
+		return available * pct / 100, true
+	default:
+		return 0, false
+	}
 }

--- a/testdata/golden/widget/container_overflow_initial.golden
+++ b/testdata/golden/widget/container_overflow_initial.golden
@@ -1,0 +1,3 @@
+line1
+line2
+line3

--- a/testdata/golden/widget/container_overflow_scrolled.golden
+++ b/testdata/golden/widget/container_overflow_scrolled.golden
@@ -1,0 +1,3 @@
+line2
+line3
+line4


### PR DESCRIPTION
This adds container height/max-height constraints plus overflow scrolling backed by a Bubble viewport. It also makes overflow-scroll containers, log widgets, and code widgets participate in keyboard focus by default, while explicitly opting passive demo logs out of tab order where needed. The widget catalog, backlog note, and coverage were updated with new render/focus tests and golden snapshots for clipped/scrolled container output. Validation passed with go test ./... and golangci-lint v2.