### PR TITLE
Add reactive script state and computed propagation

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -154,10 +154,11 @@ Items not tied to a milestone. Will be scheduled as needed.
 - **TDD**: layout calculation unit tests for grow/shrink/wrap scenarios
 
 ### Script runtime: state in computed props & cross-node state
-- Make `state` readable from computed props (currently only `$` props are accessible)
-- Add `$('other-node').state` for cross-node state sharing
+- Top-level `state` reads in computed props landed on 2026-03-13
+- `$('other-node').state` is now available for cross-node local state sharing
 - Eliminates the hidden-input workaround for shared reactive state
 - Key enabler for client-side-heavy UIs (games, dashboards with complex local logic)
+- Current limit: nested object mutation is not tracked yet; only top-level reads/writes are reactive
 - **TDD**: computed prop reads state, cross-node state access, reactivity triggers
 
 ### Script runtime: timers (setTimeout/setInterval)
@@ -166,6 +167,22 @@ Items not tied to a milestone. Will be scheduled as needed.
 - Must integrate with bubbletea's `tea.Tick` command pattern
 - Safety: max duration cap, max concurrent timers, auto-cancel on node removal
 - **TDD**: timer fires, timer cancels on remove, max limits enforced
+
+### Script runtime follow-ups
+- Automatic computed propagation after script execution
+- Note: dirty tracking exists now, but some paths still rely on callers to trigger propagation explicitly. Push this into the runtime so hooks/state writes behave consistently.
+- Current-node dependency tracking for `$.…` reads
+- Note: `$('id')` and top-level `state` reads are tracked, but self-reads like `$.value` and `$.props.foo` should also register dependencies so computed props re-run when the same node changes.
+- Runtime/script-state introspection for clients
+- Note: extend `query` or add a small runtime inspection tool so clients can debug `state` and computed behavior without guessing.
+- Richer `describe_scripting` payloads
+- Note: add hook payload schemas and concrete examples per hook/widget so clients know what `event` contains and how to compose local logic.
+- Timers / `on_tick`
+- Note: highest-leverage new feature after reactivity correctness. Keep hard caps, cleanup on node removal, and Bubble Tea integration.
+- Session persistence for script state
+- Note: once state becomes a real local data store, snapshots/restarts should include it.
+- Nested reactive state
+- Note: defer until there is real pressure from demos or clients. Recursive proxies add complexity and overhead fast.
 
 ### BubbleTea ecosystem widget integration
 - Progress bar widget (from `bubbles/progress`)

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -64,7 +64,7 @@ const serverInstructions = `imagine-tui is an MCP server that renders interactiv
 
 ## Key tools
 - describe_widgets: Discover widget types (call this first!)
-- describe_scripting: Learn the reactive scripting system (hooks, $ API, computed props, emit, state, $.state, $('id').state)
+- describe_scripting: Learn the reactive scripting system (hooks, $ API, computed props, emit, state, $.state, $('id').state, timers)
 - layout: Define UI structure (container, text, list, table, button, input, etc.)
 - set_items / append_items / remove_items: Efficiently populate list, table, and log widgets with data
 - patch: Incremental DOM updates (update props, insert/remove nodes)
@@ -681,7 +681,7 @@ func (s *Server) handleDescribeWidgets(_ context.Context, req *mcp.CallToolReque
 func describeScriptingTool() *mcp.Tool {
 	return &mcp.Tool{
 		Name:        "describe_scripting",
-		Description: "Describe the reactive scripting system: lifecycle hooks, the $ node API, computed props, emit, and state. Call this to learn how to add client-side logic to widgets.",
+		Description: "Describe the reactive scripting system: lifecycle hooks, the $ node API, computed props, emit, state, and timers. Call this to learn how to add client-side logic to widgets.",
 		InputSchema: schema(nil),
 	}
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -64,13 +64,18 @@ const serverInstructions = `imagine-tui is an MCP server that renders interactiv
 
 ## Key tools
 - describe_widgets: Discover widget types (call this first!)
-- describe_scripting: Learn the reactive scripting system (hooks, $ API, computed props, emit)
+- describe_scripting: Learn the reactive scripting system (hooks, $ API, computed props, emit, state, $.state, $('id').state)
 - layout: Define UI structure (container, text, list, table, button, input, etc.)
 - set_items / append_items / remove_items: Efficiently populate list, table, and log widgets with data
 - patch: Incremental DOM updates (update props, insert/remove nodes)
 - await_event: Long-poll for user events (click, select, submit, change)
 - query: Read current node state
 - snapshot / restore: Save and restore UI checkpoints
+
+## Reactive scripting
+If you add scripts or computed props, call describe_scripting before writing them.
+It documents hook names, emit(), per-node state, and reactive state access via $.state and $('id').state.
+Current state reactivity is top-level only: reads like state.count or $('store').state.count are tracked, but nested object mutation is not tracked yet.
 
 ## Widget overview
 Widgets include: container (layout), text, list (navigable with up/down/enter),
@@ -734,6 +739,7 @@ func scriptingCatalog() *scriptingInfo {
 			{Name: "$", Description: "Current node proxy. Read/write props: $.value, $.text, $.style, $.visible, $.rows, $.props.{key}"},
 			{Name: "$.id", Description: "Node ID", ReadOnly: true},
 			{Name: "$.type", Description: "Node type", ReadOnly: true},
+			{Name: "$.state", Description: "Current node's persistent state object. Top-level reads in computed props are reactive; top-level writes mark the node dirty.", ReadOnly: true},
 			{Name: "$.value", Description: "The node's value (for inputs, textareas, selects)"},
 			{Name: "$.props", Description: "All props as an object — read or write individual keys"},
 			{Name: "$.style", Description: "Style token string"},
@@ -742,16 +748,17 @@ func scriptingCatalog() *scriptingInfo {
 			{Name: "$.children", Description: "Child node proxies (read-only array)", ReadOnly: true},
 			{Name: "$.rows", Description: "Table rows array"},
 			{Name: "$('id')", Description: "Look up any node by ID and return a proxy with the same read/write API"},
+			{Name: "$('id').state", Description: "Another node's persistent state object. Use this for shared local state across widgets; top-level reads and writes are reactive."},
 		},
 		Globals: []apiEntry{
 			{Name: "emit('local', patchOps)", Description: "Apply a DOM patch synchronously from within the script (no MCP round-trip)"},
 			{Name: "emit('agent', data)", Description: "Queue an event for the MCP client (delivered via await_event)"},
-			{Name: "state", Description: "Per-node persistent JavaScript object — survives across hook invocations"},
+			{Name: "state", Description: "Per-node persistent JavaScript object — alias for $.state. Top-level reads in computed props are reactive; top-level writes dirty the node. nested object mutation is not tracked yet."},
 			{Name: "event", Description: "The hook payload object (e.g., key info for on_key, value for on_change). Only defined during hook execution."},
 			{Name: "debug(...args)", Description: "Log to the server's debug output (not visible in TUI)"},
 		},
 		Computed: computedInfo{
-			Description: "Computed props are reactive expressions that auto-update when dependencies change. Declare them in the node's computed map. Dependencies are tracked automatically via $ access.",
+			Description: "Computed props are reactive expressions that auto-update when dependencies change. Declare them in the node's computed map. Dependencies are tracked automatically via $ access and top-level state reads such as state.count, $.state.count, and $('store').state.count. nested object mutation is not tracked yet.",
 			Declaration: "In node spec: {\"computed\": {\"display_text\": \"return $.value.toUpperCase()\"}}",
 		},
 		Sandbox: sandboxInfo{
@@ -762,6 +769,10 @@ func scriptingCatalog() *scriptingInfo {
 			{
 				Title: "Computed prop: live character count",
 				Code:  `{"computed": {"char_count": "return 'Characters: ' + ($.value || '').length"}}`,
+			},
+			{
+				Title: "Computed prop: shared state from another node",
+				Code:  `{"computed": {"status": "return $('filters').state.activeCount + ' active filters'"}}`,
 			},
 			{
 				Title: "on_change hook: filter a list when input changes",

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -1755,7 +1755,7 @@ func TestDescribeScripting_ReturnsDollarAPI(t *testing.T) {
 	result := callHandlerDirect(t, s, "describe_scripting", map[string]any{})
 	text := resultText(t, result)
 
-	for _, api := range []string{"$.value", "$.props", "$('id')"} {
+	for _, api := range []string{"$.value", "$.props", "$.state", "$('id')", "$('id').state"} {
 		if !strings.Contains(text, api) {
 			t.Errorf("missing $ API entry %q in describe_scripting response", api)
 		}
@@ -1773,6 +1773,21 @@ func TestDescribeScripting_ReturnsGlobals(t *testing.T) {
 	for _, global := range []string{"emit", "state", "event", "debug"} {
 		if !strings.Contains(text, global) {
 			t.Errorf("missing global %q in describe_scripting response", global)
+		}
+	}
+}
+
+func TestDescribeScripting_DocumentsStateReactivityLimits(t *testing.T) {
+	s, err := NewServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := callHandlerDirect(t, s, "describe_scripting", map[string]any{})
+	text := resultText(t, result)
+
+	for _, want := range []string{"top-level", "reactive", "nested object mutation is not tracked"} {
+		if !strings.Contains(text, want) {
+			t.Errorf("missing state reactivity guidance %q in describe_scripting response", want)
 		}
 	}
 }

--- a/internal/script/computed.go
+++ b/internal/script/computed.go
@@ -10,8 +10,8 @@ import (
 
 // DepGraph tracks computed property dependencies.
 type DepGraph struct {
-	forward map[depKey]map[string]bool // computed prop -> set of nodeIDs it reads
-	reverse map[string][]depKey        // nodeID -> computed props that depend on it
+	forward map[depKey]map[sourceKey]bool // computed prop -> set of sources it reads
+	reverse map[sourceKey][]depKey        // source -> computed props that depend on it
 }
 
 type depKey struct {
@@ -19,16 +19,29 @@ type depKey struct {
 	PropName string
 }
 
+type sourceKey struct {
+	NodeID string
+	Key    string
+}
+
+func propSource(nodeID, propName string) sourceKey {
+	return sourceKey{NodeID: nodeID, Key: "prop:" + propName}
+}
+
+func stateSource(nodeID, key string) sourceKey {
+	return sourceKey{NodeID: nodeID, Key: "state:" + key}
+}
+
 // newDepGraph creates an empty dependency graph.
 func newDepGraph() *DepGraph {
 	return &DepGraph{
-		forward: make(map[depKey]map[string]bool),
-		reverse: make(map[string][]depKey),
+		forward: make(map[depKey]map[sourceKey]bool),
+		reverse: make(map[sourceKey][]depKey),
 	}
 }
 
 // Update sets the dependencies for a computed prop, updating both forward and reverse maps.
-func (dg *DepGraph) Update(key depKey, accessed map[string]bool) {
+func (dg *DepGraph) Update(key depKey, accessed map[sourceKey]bool) {
 	// Remove old reverse entries.
 	if old, ok := dg.forward[key]; ok {
 		for oldDep := range old {
@@ -45,7 +58,24 @@ func (dg *DepGraph) Update(key depKey, accessed map[string]bool) {
 
 // Dependents returns all computed props that depend on the given nodeID.
 func (dg *DepGraph) Dependents(nodeID string) []depKey {
-	return dg.reverse[nodeID]
+	set := make(map[depKey]bool)
+	for source, deps := range dg.reverse {
+		if source.NodeID != nodeID {
+			continue
+		}
+		for _, dk := range deps {
+			set[dk] = true
+		}
+	}
+	result := make([]depKey, 0, len(set))
+	for dk := range set {
+		result = append(result, dk)
+	}
+	return result
+}
+
+func (dg *DepGraph) dependentsForSource(source sourceKey) []depKey {
+	return dg.reverse[source]
 }
 
 // RemoveNode removes all entries for a node (both as a dependency and as a computed prop owner).
@@ -60,7 +90,11 @@ func (dg *DepGraph) RemoveNode(nodeID string) {
 		}
 	}
 	// Remove as a dependency source.
-	delete(dg.reverse, nodeID)
+	for source := range dg.reverse {
+		if source.NodeID == nodeID {
+			delete(dg.reverse, source)
+		}
+	}
 }
 
 // DetectCycle checks if evaluating the given computed prop would eventually
@@ -68,40 +102,40 @@ func (dg *DepGraph) RemoveNode(nodeID string) {
 // evaluating dk dirties dk.NodeID → computed props depending on dk.NodeID
 // get re-evaluated → dirtying their nodes → etc. Returns true if a cycle exists.
 func (dg *DepGraph) DetectCycle(startKey depKey) bool {
-	visited := make(map[string]bool)
-	return dg.wouldTrigger(startKey.NodeID, startKey, visited)
+	visited := make(map[sourceKey]bool)
+	return dg.wouldTrigger(propSource(startKey.NodeID, startKey.PropName), startKey, visited)
 }
 
 // wouldTrigger checks if dirtying dirtyNodeID would eventually cause target
 // to need re-evaluation.
-func (dg *DepGraph) wouldTrigger(dirtyNodeID string, target depKey, visited map[string]bool) bool {
-	if visited[dirtyNodeID] {
+func (dg *DepGraph) wouldTrigger(dirtySource sourceKey, target depKey, visited map[sourceKey]bool) bool {
+	if visited[dirtySource] {
 		return false
 	}
-	visited[dirtyNodeID] = true
+	visited[dirtySource] = true
 
-	for _, dk := range dg.reverse[dirtyNodeID] {
+	for _, dk := range dg.reverse[dirtySource] {
 		if dk == target {
 			return true
 		}
 		// Evaluating dk would dirty dk.NodeID.
-		if dg.wouldTrigger(dk.NodeID, target, visited) {
+		if dg.wouldTrigger(propSource(dk.NodeID, dk.PropName), target, visited) {
 			return true
 		}
 	}
 	return false
 }
 
-func (dg *DepGraph) removeReverse(nodeID string, key depKey) {
-	deps := dg.reverse[nodeID]
+func (dg *DepGraph) removeReverse(source sourceKey, key depKey) {
+	deps := dg.reverse[source]
 	for i, dk := range deps {
 		if dk == key {
-			dg.reverse[nodeID] = append(deps[:i], deps[i+1:]...)
+			dg.reverse[source] = append(deps[:i], deps[i+1:]...)
 			break
 		}
 	}
-	if len(dg.reverse[nodeID]) == 0 {
-		delete(dg.reverse, nodeID)
+	if len(dg.reverse[source]) == 0 {
+		delete(dg.reverse, source)
 	}
 }
 
@@ -109,7 +143,7 @@ func (dg *DepGraph) removeReverse(nodeID string, key depKey) {
 type evalCtx struct {
 	ownerNodeID string
 	propName    string
-	accessed    map[string]bool
+	accessed    map[sourceKey]bool
 }
 
 // EvalComputed evaluates a computed prop expression and returns the result.
@@ -137,7 +171,7 @@ func (rt *Runtime) evalComputedLocked(nodeID, propName, expr string) (any, error
 	rt.currentEval = &evalCtx{
 		ownerNodeID: nodeID,
 		propName:    propName,
-		accessed:    make(map[string]bool),
+		accessed:    make(map[sourceKey]bool),
 	}
 	defer func() { rt.currentEval = nil }()
 
@@ -173,43 +207,74 @@ func (rt *Runtime) PropagateChanges() error {
 	rt.mu.Lock()
 	defer rt.mu.Unlock()
 
+	return rt.propagateChangesLocked(nil)
+}
+
+// propagateChangesLocked re-evaluates computed props that depend on dirty nodes.
+// Must be called with rt.mu held. If changed is non-nil, all directly dirty and
+// recomputed node IDs are recorded into it.
+func (rt *Runtime) propagateChangesLocked(changed map[string]bool) error {
 	const maxIterations = 100
 	for i := 0; i < maxIterations; i++ {
-		if len(rt.dirty) == 0 {
+		if len(rt.dirty) == 0 && len(rt.dirtySources) == 0 {
 			return nil
 		}
 
 		// Snapshot and clear current dirty set.
 		batch := rt.dirty
 		rt.dirty = make(map[string]bool)
+		sourceBatch := rt.dirtySources
+		rt.dirtySources = make(map[sourceKey]bool)
 
-		for nodeID := range batch {
-			deps := rt.deps.Dependents(nodeID)
-			for _, dk := range deps {
-				// Cycle detection.
-				if rt.deps.DetectCycle(dk) {
-					return &Error{
-						NodeID:  dk.NodeID,
-						Hook:    dk.PropName,
-						Message: fmt.Sprintf("cycle detected in computed prop: %s.%s", dk.NodeID, dk.PropName),
-					}
-				}
+		pending := make(map[depKey]bool)
 
-				node := rt.tree.Find(dk.NodeID)
-				if node == nil {
-					continue
+		if len(sourceBatch) == 0 {
+			for nodeID := range batch {
+				if changed != nil {
+					changed[nodeID] = true
 				}
-				expr, ok := node.Computed[dk.PropName]
-				if !ok {
-					continue
+				for _, dk := range rt.deps.Dependents(nodeID) {
+					pending[dk] = true
 				}
+			}
+		}
 
-				val, err := rt.evalComputedLocked(dk.NodeID, dk.PropName, expr)
-				if err != nil {
-					return err
+		for source := range sourceBatch {
+			if changed != nil {
+				changed[source.NodeID] = true
+			}
+			for _, dk := range rt.deps.dependentsForSource(source) {
+				pending[dk] = true
+			}
+		}
+
+		for dk := range pending {
+			// Cycle detection.
+			if rt.deps.DetectCycle(dk) {
+				return &Error{
+					NodeID:  dk.NodeID,
+					Hook:    dk.PropName,
+					Message: fmt.Sprintf("cycle detected in computed prop: %s.%s", dk.NodeID, dk.PropName),
 				}
-				node.SetProp(dk.PropName, val)
-				rt.dirty[dk.NodeID] = true
+			}
+
+			node := rt.tree.Find(dk.NodeID)
+			if node == nil {
+				continue
+			}
+			expr, ok := node.Computed[dk.PropName]
+			if !ok {
+				continue
+			}
+
+			val, err := rt.evalComputedLocked(dk.NodeID, dk.PropName, expr)
+			if err != nil {
+				return err
+			}
+			node.SetProp(dk.PropName, val)
+			rt.markDirtyProp(dk.NodeID, dk.PropName)
+			if changed != nil {
+				changed[dk.NodeID] = true
 			}
 		}
 	}

--- a/internal/script/computed_test.go
+++ b/internal/script/computed_test.go
@@ -39,6 +39,46 @@ func TestEvalComputedReadsCrossNode(t *testing.T) {
 	}
 }
 
+func TestEvalComputedReadsCurrentNodeState(t *testing.T) {
+	rt := newTestRuntimeWithTree(t)
+
+	err := rt.execScript("child1", "test", `state.count = 2`, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	node := rt.tree.Find("child1")
+	node.Computed["text"] = `return "count:" + state.count`
+
+	val, err := rt.EvalComputed("child1", "text", node.Computed["text"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if val != "count:2" {
+		t.Errorf("expected 'count:2', got %v", val)
+	}
+}
+
+func TestEvalComputedReadsCrossNodeState(t *testing.T) {
+	rt := newTestRuntimeWithTree(t)
+
+	err := rt.execScript("child2", "test", `state.count = 4`, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	node := rt.tree.Find("child1")
+	node.Computed["text"] = `return "count:" + $('child2').state.count`
+
+	val, err := rt.EvalComputed("child1", "text", node.Computed["text"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if val != "count:4" {
+		t.Errorf("expected 'count:4', got %v", val)
+	}
+}
+
 func TestEvalComputedDependencyTracking(t *testing.T) {
 	rt := newTestRuntimeWithTree(t)
 
@@ -102,6 +142,39 @@ func TestEvalComputedReEvalOnChange(t *testing.T) {
 	v, _ := child1.GetProp("text")
 	if v != "got:updated" {
 		t.Errorf("after propagation: expected 'got:updated', got %v", v)
+	}
+}
+
+func TestEvalComputedReEvalOnStateChange(t *testing.T) {
+	rt := newTestRuntimeWithTree(t)
+
+	err := rt.execScript("child2", "test", `state.count = 1`, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	child1 := rt.tree.Find("child1")
+	child1.Computed["text"] = `return "count:" + $('child2').state.count`
+
+	val, err := rt.EvalComputed("child1", "text", child1.Computed["text"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	child1.SetProp("text", val)
+
+	err = rt.execScript("child2", "test", `state.count = 2`, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = rt.PropagateChanges()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	v, _ := child1.GetProp("text")
+	if v != "count:2" {
+		t.Errorf("after propagation: expected 'count:2', got %v", v)
 	}
 }
 

--- a/internal/script/computed_test.go
+++ b/internal/script/computed_test.go
@@ -145,6 +145,35 @@ func TestEvalComputedReEvalOnChange(t *testing.T) {
 	}
 }
 
+func TestEvalComputedReEvalOnCurrentNodePropChange(t *testing.T) {
+	rt := newTestRuntimeWithTree(t)
+
+	child2 := rt.tree.Find("child2")
+	child2.Computed["text"] = `return "self:" + $.value`
+
+	val, err := rt.EvalComputed("child2", "text", child2.Computed["text"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	child2.SetProp("text", val)
+
+	child2.SetProp("value", "updated")
+
+	rt.mu.Lock()
+	rt.dirty = map[string]bool{"child2": true}
+	rt.mu.Unlock()
+
+	err = rt.PropagateChanges()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	v, _ := child2.GetProp("text")
+	if v != "self:updated" {
+		t.Errorf("after propagation: expected 'self:updated', got %v", v)
+	}
+}
+
 func TestEvalComputedReEvalOnStateChange(t *testing.T) {
 	rt := newTestRuntimeWithTree(t)
 

--- a/internal/script/cross_node_test.go
+++ b/internal/script/cross_node_test.go
@@ -112,8 +112,8 @@ func TestCurrentNodeWriteStillWorksWithCallable(t *testing.T) {
 func TestCrossNodeReadID(t *testing.T) {
 	rt := newTestRuntimeWithTree(t)
 	err := rt.execScript("root", "test", `
-		if ($('child1').id !== "child1") {
-			throw new Error("expected 'child1', got " + $('child1').id);
+			if ($('child1').id !== "child1") {
+				throw new Error("expected 'child1', got " + $('child1').id);
 		}
 	`, nil)
 	if err != nil {
@@ -139,6 +139,45 @@ func TestCrossNodeDirtiesTarget(t *testing.T) {
 
 	if !isDirty {
 		t.Error("expected child1 to be in dirty set after cross-node write")
+	}
+}
+
+func TestCrossNodeReadState(t *testing.T) {
+	rt := newTestRuntimeWithTree(t)
+
+	err := rt.execScript("child1", "test", `state.count = 3`, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = rt.execScript("child2", "test", `
+			if ($('child1').state.count !== 3) {
+				throw new Error("expected 3, got " + $('child1').state.count);
+			}
+	`, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCrossNodeStateWriteMarksTargetDirty(t *testing.T) {
+	rt := newTestRuntimeWithTree(t)
+
+	rt.mu.Lock()
+	rt.dirty = make(map[string]bool)
+	rt.mu.Unlock()
+
+	err := rt.execScript("root", "test", `$('child1').state.count = 7`, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rt.mu.Lock()
+	isDirty := rt.dirty["child1"]
+	rt.mu.Unlock()
+
+	if !isDirty {
+		t.Error("expected child1 to be in dirty set after cross-node state write")
 	}
 }
 

--- a/internal/script/hooks.go
+++ b/internal/script/hooks.go
@@ -18,6 +18,10 @@ const (
 // Returns the set of dirty node IDs (nodes whose props were modified).
 // If the node has no script for the given hook, this is a no-op.
 func (rt *Runtime) ExecHook(nodeID string, hook HookType, payload *HookPayload) ([]string, error) {
+	return rt.execHook(nodeID, hook, payload, true)
+}
+
+func (rt *Runtime) execHook(nodeID string, hook HookType, payload *HookPayload, resetDirty bool) ([]string, error) {
 	node := rt.tree.Find(nodeID)
 	if node == nil {
 		return nil, &Error{NodeID: nodeID, Hook: string(hook), Message: "node not found"}
@@ -28,9 +32,13 @@ func (rt *Runtime) ExecHook(nodeID string, hook HookType, payload *HookPayload) 
 		return nil, nil
 	}
 
-	// Clear dirty set before execution.
+	// Clear dirty set before execution unless the caller is carrying forward an
+	// already-dirty node (for example NotifyChange setting $.value first).
 	rt.mu.Lock()
-	rt.dirty = make(map[string]bool)
+	if resetDirty {
+		rt.dirty = make(map[string]bool)
+		rt.dirtySources = make(map[sourceKey]bool)
+	}
 	rt.mu.Unlock()
 
 	err := rt.execScript(nodeID, string(hook), body, payload)
@@ -38,14 +46,18 @@ func (rt *Runtime) ExecHook(nodeID string, hook HookType, payload *HookPayload) 
 		return nil, err
 	}
 
-	// Collect dirty IDs.
 	rt.mu.Lock()
-	dirty := make([]string, 0, len(rt.dirty))
-	for id := range rt.dirty {
+	defer rt.mu.Unlock()
+
+	changed := make(map[string]bool)
+	if err := rt.propagateChangesLocked(changed); err != nil {
+		return nil, err
+	}
+
+	dirty := make([]string, 0, len(changed))
+	for id := range changed {
 		dirty = append(dirty, id)
 	}
-	rt.mu.Unlock()
-
 	return dirty, nil
 }
 
@@ -74,9 +86,16 @@ func (rt *Runtime) NotifyChange(nodeID string, newValue any) error {
 	}
 
 	node.SetProp("value", newValue)
+	rt.mu.Lock()
+	rt.markDirtyProp(nodeID, "value")
+	rt.mu.Unlock()
 
-	_, err := rt.ExecHook(nodeID, HookOnChange, &HookPayload{
-		Data: map[string]any{"value": newValue},
-	})
-	return err
+	if body, ok := node.Scripts[string(HookOnChange)]; ok && body != "" {
+		_, err := rt.execHook(nodeID, HookOnChange, &HookPayload{
+			Data: map[string]any{"value": newValue},
+		}, false)
+		return err
+	}
+
+	return rt.PropagateChanges()
 }

--- a/internal/script/hooks_test.go
+++ b/internal/script/hooks_test.go
@@ -233,6 +233,28 @@ func TestNotifyChange(t *testing.T) {
 	}
 }
 
+func TestNotifyChangeAutoPropagatesComputed(t *testing.T) {
+	rt := newTestRuntimeWithTree(t)
+
+	child1 := rt.tree.Find("child1")
+	child1.Computed["text"] = `return "got:" + $('child2').value`
+
+	err := rt.EvalAllComputed()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = rt.NotifyChange("child2", "updated")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	txt, _ := child1.GetProp("text")
+	if txt != "got:updated" {
+		t.Errorf("expected text='got:updated', got %v", txt)
+	}
+}
+
 func TestNotifyChangeNoScript(t *testing.T) {
 	rt := newTestRuntimeWithTree(t)
 

--- a/internal/script/proxy.go
+++ b/internal/script/proxy.go
@@ -32,14 +32,19 @@ func (p *nodeProxy) Get(key string) goja.Value {
 	case "state":
 		return p.rt.makeStateProxy(p.node.ID)
 	case "value":
+		p.rt.recordSourceDep(propSource(p.node.ID, "value"))
 		return p.propValue("value")
 	case "props":
+		p.rt.recordSourceDep(propSource(p.node.ID, "props"))
 		return p.rt.vm.ToValue(p.node.Props)
 	case "style":
+		p.rt.recordSourceDep(propSource(p.node.ID, "style"))
 		return p.propValue("style")
 	case "text":
+		p.rt.recordSourceDep(propSource(p.node.ID, "text"))
 		return p.propValue("text")
 	case "visible":
+		p.rt.recordSourceDep(propSource(p.node.ID, "visible"))
 		v, ok := p.node.GetProp("visible")
 		if !ok {
 			return p.rt.vm.ToValue(true) // default visible
@@ -48,8 +53,10 @@ func (p *nodeProxy) Get(key string) goja.Value {
 	case "children":
 		return p.rt.makeChildArray(p.node)
 	case "rows":
+		p.rt.recordSourceDep(propSource(p.node.ID, "rows"))
 		return p.propValue("rows")
 	default:
+		p.rt.recordSourceDep(propSource(p.node.ID, key))
 		return p.propValue(key)
 	}
 }
@@ -62,7 +69,7 @@ func (p *nodeProxy) Set(key string, val goja.Value) bool {
 		return false
 	}
 	p.node.SetProp(key, val.Export())
-	p.rt.markDirty(p.node.ID)
+	p.rt.markDirtyProp(p.node.ID, key)
 	return true
 }
 
@@ -70,6 +77,7 @@ func (p *nodeProxy) Has(key string) bool {
 	if p.node == nil {
 		return false
 	}
+	p.rt.recordSourceDep(propSource(p.node.ID, "props"))
 	switch key {
 	case "id", "type", "state", "value", "props", "style", "text", "visible", "children", "rows":
 		return true
@@ -87,6 +95,7 @@ func (p *nodeProxy) Keys() []string {
 	if p.node == nil {
 		return nil
 	}
+	p.rt.recordSourceDep(propSource(p.node.ID, "props"))
 	keys := []string{"id", "type", "state", "value", "props", "style", "text", "visible", "children"}
 	for k := range p.node.Props {
 		// Avoid duplicates with the well-known keys above.
@@ -123,4 +132,20 @@ func (rt *Runtime) makeChildArray(node *dom.Node) goja.Value {
 // Must be called with rt.mu held.
 func (rt *Runtime) markDirty(nodeID string) {
 	rt.dirty[nodeID] = true
+}
+
+// markDirtyProp records a precise prop change while keeping node-level dirty
+// bookkeeping for callers and tests that only care which nodes changed.
+// Must be called with rt.mu held.
+func (rt *Runtime) markDirtyProp(nodeID, propName string) {
+	rt.markDirty(nodeID)
+	rt.dirtySources[propSource(nodeID, propName)] = true
+	rt.dirtySources[propSource(nodeID, "props")] = true
+}
+
+// markDirtyState records a precise top-level state change.
+// Must be called with rt.mu held.
+func (rt *Runtime) markDirtyState(nodeID, key string) {
+	rt.markDirty(nodeID)
+	rt.dirtySources[stateSource(nodeID, key)] = true
 }

--- a/internal/script/proxy.go
+++ b/internal/script/proxy.go
@@ -17,6 +17,7 @@ var readOnlyProps = map[string]bool{
 	"id":       true,
 	"type":     true,
 	"children": true,
+	"state":    true,
 }
 
 func (p *nodeProxy) Get(key string) goja.Value {
@@ -28,6 +29,8 @@ func (p *nodeProxy) Get(key string) goja.Value {
 		return p.rt.vm.ToValue(p.node.ID)
 	case "type":
 		return p.rt.vm.ToValue(string(p.node.Type))
+	case "state":
+		return p.rt.makeStateProxy(p.node.ID)
 	case "value":
 		return p.propValue("value")
 	case "props":
@@ -68,7 +71,7 @@ func (p *nodeProxy) Has(key string) bool {
 		return false
 	}
 	switch key {
-	case "id", "type", "value", "props", "style", "text", "visible", "children", "rows":
+	case "id", "type", "state", "value", "props", "style", "text", "visible", "children", "rows":
 		return true
 	default:
 		_, ok := p.node.GetProp(key)
@@ -84,7 +87,7 @@ func (p *nodeProxy) Keys() []string {
 	if p.node == nil {
 		return nil
 	}
-	keys := []string{"id", "type", "value", "props", "style", "text", "visible", "children"}
+	keys := []string{"id", "type", "state", "value", "props", "style", "text", "visible", "children"}
 	for k := range p.node.Props {
 		// Avoid duplicates with the well-known keys above.
 		switch k {

--- a/internal/script/runtime.go
+++ b/internal/script/runtime.go
@@ -16,16 +16,17 @@ const defaultTimeout = 10 * time.Millisecond
 // Runtime is the script execution engine for a session.
 // It owns a single goja VM and manages per-node state.
 type Runtime struct {
-	mu          sync.Mutex
-	vm          *goja.Runtime
-	tree        *dom.Tree
-	events      *dom.EventQueue
-	states      map[string]*goja.Object // nodeID -> persistent JS state
-	deps        *DepGraph               // computed prop dependency tracking
-	dirty       map[string]bool         // nodes modified since last propagation
-	currentEval *evalCtx                // non-nil during computed prop eval
-	timeout     time.Duration
-	debugLog    func(string)
+	mu           sync.Mutex
+	vm           *goja.Runtime
+	tree         *dom.Tree
+	events       *dom.EventQueue
+	states       map[string]*goja.Object // nodeID -> persistent JS state
+	deps         *DepGraph               // computed prop dependency tracking
+	dirty        map[string]bool         // nodes modified since last propagation
+	dirtySources map[sourceKey]bool      // precise prop/state sources modified since last propagation
+	currentEval  *evalCtx                // non-nil during computed prop eval
+	timeout      time.Duration
+	debugLog     func(string)
 }
 
 // Option configures the Runtime.
@@ -48,13 +49,14 @@ func WithDebugLog(fn func(string)) Option {
 // New creates a new script Runtime bound to a DOM tree and event queue.
 func New(tree *dom.Tree, events *dom.EventQueue, opts ...Option) *Runtime {
 	rt := &Runtime{
-		vm:      goja.New(),
-		tree:    tree,
-		events:  events,
-		states:  make(map[string]*goja.Object),
-		deps:    newDepGraph(),
-		dirty:   make(map[string]bool),
-		timeout: defaultTimeout,
+		vm:           goja.New(),
+		tree:         tree,
+		events:       events,
+		states:       make(map[string]*goja.Object),
+		deps:         newDepGraph(),
+		dirty:        make(map[string]bool),
+		dirtySources: make(map[sourceKey]bool),
+		timeout:      defaultTimeout,
 	}
 	for _, opt := range opts {
 		opt(rt)
@@ -144,8 +146,6 @@ func (rt *Runtime) setupContext(node *dom.Node, payload *HookPayload) {
 		}
 		id := call.Arguments[0].String()
 		target := rt.tree.Find(id)
-		// Record dependency if we're evaluating a computed prop.
-		rt.recordDep(id)
 		return rt.vm.NewDynamicObject(&nodeProxy{rt: rt, node: target})
 	})
 
@@ -176,11 +176,12 @@ func (rt *Runtime) setupContext(node *dom.Node, payload *HookPayload) {
 	}
 }
 
-// recordDep records a dependency on the given nodeID during computed prop evaluation.
-// No-op unless a computed prop evaluation is in progress. Must be called with rt.mu held.
-func (rt *Runtime) recordDep(nodeID string) {
+// recordSourceDep records a dependency on a specific source during computed prop
+// evaluation. No-op unless a computed prop evaluation is in progress. Must be
+// called with rt.mu held.
+func (rt *Runtime) recordSourceDep(source sourceKey) {
 	if rt.currentEval != nil {
-		rt.currentEval.accessed[nodeID] = true
+		rt.currentEval.accessed[source] = true
 	}
 }
 

--- a/internal/script/runtime.go
+++ b/internal/script/runtime.go
@@ -163,8 +163,7 @@ func (rt *Runtime) setupContext(node *dom.Node, payload *HookPayload) {
 	_ = rt.vm.Set("$", p)
 
 	// Bind per-node state object.
-	state := rt.getOrCreateState(node.ID)
-	_ = rt.vm.Set("state", state)
+	_ = rt.vm.Set("state", rt.makeStateProxy(node.ID))
 
 	// Bind emit function.
 	_ = rt.vm.Set("emit", rt.makeEmitFn(node.ID))

--- a/internal/script/state.go
+++ b/internal/script/state.go
@@ -21,7 +21,7 @@ type stateProxy struct {
 }
 
 func (p *stateProxy) Get(key string) goja.Value {
-	p.rt.recordDep(p.nodeID)
+	p.rt.recordSourceDep(stateSource(p.nodeID, key))
 
 	state := p.rt.getOrCreateState(p.nodeID)
 	val := state.Get(key)
@@ -36,12 +36,12 @@ func (p *stateProxy) Set(key string, val goja.Value) bool {
 	if err := state.Set(key, val); err != nil {
 		return false
 	}
-	p.rt.markDirty(p.nodeID)
+	p.rt.markDirtyState(p.nodeID, key)
 	return true
 }
 
 func (p *stateProxy) Has(key string) bool {
-	p.rt.recordDep(p.nodeID)
+	p.rt.recordSourceDep(stateSource(p.nodeID, key))
 
 	state := p.rt.getOrCreateState(p.nodeID)
 	val := state.Get(key)
@@ -53,13 +53,11 @@ func (p *stateProxy) Delete(key string) bool {
 	if err := state.Delete(key); err != nil {
 		return false
 	}
-	p.rt.markDirty(p.nodeID)
+	p.rt.markDirtyState(p.nodeID, key)
 	return true
 }
 
 func (p *stateProxy) Keys() []string {
-	p.rt.recordDep(p.nodeID)
-
 	state := p.rt.getOrCreateState(p.nodeID)
 	keys := state.Keys()
 	if keys == nil {

--- a/internal/script/state.go
+++ b/internal/script/state.go
@@ -13,6 +13,68 @@ func (rt *Runtime) getOrCreateState(nodeID string) *goja.Object {
 	return s
 }
 
+// stateProxy exposes top-level state reads/writes while keeping the backing
+// object persistent across script invocations.
+type stateProxy struct {
+	rt     *Runtime
+	nodeID string
+}
+
+func (p *stateProxy) Get(key string) goja.Value {
+	p.rt.recordDep(p.nodeID)
+
+	state := p.rt.getOrCreateState(p.nodeID)
+	val := state.Get(key)
+	if val == nil {
+		return goja.Undefined()
+	}
+	return val
+}
+
+func (p *stateProxy) Set(key string, val goja.Value) bool {
+	state := p.rt.getOrCreateState(p.nodeID)
+	if err := state.Set(key, val); err != nil {
+		return false
+	}
+	p.rt.markDirty(p.nodeID)
+	return true
+}
+
+func (p *stateProxy) Has(key string) bool {
+	p.rt.recordDep(p.nodeID)
+
+	state := p.rt.getOrCreateState(p.nodeID)
+	val := state.Get(key)
+	return val != nil && !goja.IsUndefined(val)
+}
+
+func (p *stateProxy) Delete(key string) bool {
+	state := p.rt.getOrCreateState(p.nodeID)
+	if err := state.Delete(key); err != nil {
+		return false
+	}
+	p.rt.markDirty(p.nodeID)
+	return true
+}
+
+func (p *stateProxy) Keys() []string {
+	p.rt.recordDep(p.nodeID)
+
+	state := p.rt.getOrCreateState(p.nodeID)
+	keys := state.Keys()
+	if keys == nil {
+		return []string{}
+	}
+	return keys
+}
+
+// makeStateProxy returns a JS object that proxies top-level state access for a node.
+// Must be called with rt.mu held.
+func (rt *Runtime) makeStateProxy(nodeID string) goja.Value {
+	rt.getOrCreateState(nodeID)
+	return rt.vm.NewDynamicObject(&stateProxy{rt: rt, nodeID: nodeID})
+}
+
 // removeState deletes the per-node state for the given node ID.
 // Called when a node is removed from the DOM.
 func (rt *Runtime) removeState(nodeID string) {

--- a/internal/script/state_test.go
+++ b/internal/script/state_test.go
@@ -158,3 +158,24 @@ func TestStateDefaultsToEmptyObject(t *testing.T) {
 		t.Fatalf("state defaults: %v", err)
 	}
 }
+
+func TestStateWriteMarksCurrentNodeDirty(t *testing.T) {
+	rt := newTestRuntime(t)
+
+	rt.mu.Lock()
+	rt.dirty = make(map[string]bool)
+	rt.mu.Unlock()
+
+	err := rt.execScript("root", "test", `state.count = 1`, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rt.mu.Lock()
+	isDirty := rt.dirty["root"]
+	rt.mu.Unlock()
+
+	if !isDirty {
+		t.Error("expected root to be in dirty set after state write")
+	}
+}

--- a/internal/script/timer_test.go
+++ b/internal/script/timer_test.go
@@ -113,6 +113,34 @@ func TestSetIntervalFiresUntilCleared(t *testing.T) {
 	}
 }
 
+func TestTimerCallbackAutoPropagatesComputed(t *testing.T) {
+	rt := newTestRuntimeWithTree(t)
+
+	child2 := rt.tree.Find("child2")
+	child2.Computed["text"] = `return "count:" + ($('child1').state.count || 0)`
+	if err := rt.EvalAllComputed(); err != nil {
+		t.Fatalf("EvalAllComputed: %v", err)
+	}
+
+	if err := rt.execScript("child1", "test", `
+		setTimeout(function() {
+			state.count = 1;
+		}, 10)
+	`, nil); err != nil {
+		t.Fatalf("execScript: %v", err)
+	}
+
+	if ran, err := rt.RunDueTimers(time.Now().Add(20 * time.Millisecond)); err != nil {
+		t.Fatalf("RunDueTimers when due: %v", err)
+	} else if !ran {
+		t.Fatal("expected timer callback to run")
+	}
+
+	if got, _ := child2.GetProp("text"); got != "count:1" {
+		t.Fatalf("expected computed text to update after timer callback, got %v", got)
+	}
+}
+
 func TestRunDueTimersAutoPropagatesComputedChanges(t *testing.T) {
 	rt := newTestRuntimeWithTree(t)
 


### PR DESCRIPTION
Adds top-level reactive script state, including $.state, source-aware computed dependency tracking, and automatic propagation after hook/change execution. Timer callbacks now participate in the same propagation path, with added regression coverage for timer-driven prop and state updates. Updates describe_scripting/server instructions and backlog notes so clients see the new state and timer capabilities. Verification: go test ./... and go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.0 run.